### PR TITLE
WinMerge - add exe path to %ProgramFiles%

### DIFF
--- a/src/DiffEngine/Implementation/WinMerge.cs
+++ b/src/DiffEngine/Implementation/WinMerge.cs
@@ -21,7 +21,8 @@ static partial class Implementation
                     var rightTitle = Path.GetFileName(target);
                     return $"/u /wl /e \"{temp}\" \"{target}\" /dl \"{leftTitle}\" /dr \"{rightTitle}\"";
                 },
-                @"%ProgramFiles(x86)%\WinMerge\WinMergeU.exe"),
+                @"%ProgramFiles(x86)%\WinMerge\WinMergeU.exe",
+                @"%ProgramFiles%\WinMerge\WinMergeU.exe"),
             notes: @"
  * [Command line reference](https://manual.winmerge.org/en/Command_line.html).
  * `/u` Prevents WinMerge from adding paths to the Most Recently Used (MRU) list.


### PR DESCRIPTION
WinMerge isn't working for me since ApprovalTests 5 which uses DiffEngine.
Turns out my WinMerge is at `C:\Program Files\WinMerge`.
Don't know if x86 install is possible, but I left it in.