### PR TITLE
fix osx process finder when zsh is installed

### DIFF
--- a/src/DiffEngine.Tests/LinuxOsxProcessTests.cs
+++ b/src/DiffEngine.Tests/LinuxOsxProcessTests.cs
@@ -4,6 +4,17 @@ using Xunit.Abstractions;
 public class LinuxOsxProcessTests :
     XunitContextBase
 {
+
+    [Fact]
+    public void TryParseWithZshInstalled()
+    {
+        var parse = LinuxOsxProcess.TryParse("20872 -zsh", out var command);
+        Assert.True(parse);
+        var processCommand = command!.Value;
+        Assert.Equal(20872, processCommand.Process);
+        Assert.Equal("-zsh", processCommand.Command);
+    }
+    
     [Fact]
     public void TryParse()
     {

--- a/src/DiffEngine/Process/LinuxOsxProcess.cs
+++ b/src/DiffEngine/Process/LinuxOsxProcess.cs
@@ -64,9 +64,18 @@ static class LinuxOsxProcess
             var pid = int.Parse(pidString);
 
             var timeAndCommandString = trim.Substring(firstSpace + 1);
-            var multiSpaceIndex = timeAndCommandString.IndexOf("   ", firstSpace);
-
-            var command = timeAndCommandString.Substring(multiSpaceIndex + 1).Trim();
+            var multiSpaceIndex = 0;
+            string command;
+            
+            if (timeAndCommandString.IndexOf("   ", StringComparison.InvariantCulture) > 0)
+            {
+                multiSpaceIndex = timeAndCommandString.IndexOf("   ", firstSpace, StringComparison.InvariantCulture);
+                command = timeAndCommandString.Substring(multiSpaceIndex + 1).Trim();
+            }
+            else
+            {
+                command = timeAndCommandString.Substring(multiSpaceIndex).Trim();
+            }
 
             processCommand = new ProcessCommand(command, in pid);
             return true;


### PR DESCRIPTION
I'm using Zsh as my default shell on my mac. The output of the command `ps -o pid,command -x` is the following (shortened):

```
...
20870 /Applications/iTerm.app/Contents/MacOS/iTerm2 --server login -fp hadi
20872 -zsh
```

This will blow up the process finder and the diff engine altogether. The accompanying test shows the problem and the code tweak in LinuxOsxProcess.cs fixes the issue.