### PR TITLE
Fix documentation links

### DIFF
--- a/docs/code-verus-machine-settings.md
+++ b/docs/code-verus-machine-settings.md
@@ -21,7 +21,7 @@ Settings that are personal preferences ideally should
 Examples:
 
  * [Custom order](diff-tool.order.md#custom-order) which depend on the tools a specific person has installed.
- * [Disable launching](/#disable-for-a-machineprocess).
+ * [Disable launching](/readme.md#disable-for-a-machineprocess).
  * [Max instances to launch](diff-tool.md#maxinstancestolaunch).
 
 
@@ -36,5 +36,5 @@ Settings that are shared ideally should
 
 Examples:
 
- * [File type detection](/#file-type-detection).
- * [Adding a share custom tool](/diff-tool.custom.md). A team may be comparing custom file types, and require a shared custom tool to verify that file.
+ * [File type detection](/readme.md#file-type-detection).
+ * [Adding a share custom tool](/docs/diff-tool.custom.md). A team may be comparing custom file types, and require a shared custom tool to verify that file.


### PR DESCRIPTION
I noticed that there are some broken links in the documentation, so this PR fixes those.

I assume the typo in the file name `code-verus-machine-settings.md` is intended for backwards compatibility?