### PR TITLE
invoke diff in VisualStudio in the correct order

### DIFF
--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -639,7 +639,7 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
 
 #### Windows settings:
 
- * Example arguments: `/diff "tempFile" "targetFile"`
+ * Example arguments: `/diff "targetFile" "tempFile"`
  * Scanned paths:
 
    * `%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\Common7\IDE\devenv.exe`

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -539,7 +539,7 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
 
 #### Windows settings:
 
- * Example arguments: `/diff "tempFile" "targetFile"`
+ * Example arguments: `/diff "targetFile" "tempFile"`
  * Scanned paths:
 
    * `%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\Common7\IDE\devenv.exe`

--- a/src/DiffEngine/Implementation/VisualStudio.cs
+++ b/src/DiffEngine/Implementation/VisualStudio.cs
@@ -15,7 +15,7 @@ static partial class Implementation
             cost: "Paid and free options",
             binaryExtensions: Array.Empty<string>(),
             windows: new(
-                (temp, target) => $"/diff \"{temp}\" \"{target}\"",
+                (temp, target) => $"/diff \"{target}\" \"{temp}\"",
                 @"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\Common7\IDE\devenv.exe",
                 @"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\Common7\IDE\devenv.exe",
                 @"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Professional\Common7\IDE\devenv.exe",


### PR DESCRIPTION
Issue: https://github.com/approvals/ApprovalTests.Net/issues/549
- changed order of `tempFile` and `targetFile`
- .md files have been auto-adjusted

Now the position of the compared files is more intuitive, i.e.
- new file (received): right-hand side
- current file (approved): left-hand side
![image](https://user-images.githubusercontent.com/47413092/128402610-43cf64b7-6ecc-4390-a48f-03b2f5744b40.png)