### PR TITLE
do not throw an exception when the payload content is empty

### DIFF
--- a/src/DiffEngineTray/PiperServer.cs
+++ b/src/DiffEngineTray/PiperServer.cs
@@ -72,7 +72,10 @@ static class PiperServer
             }
             else
             {
-                throw new($"Unknown payload: {payload}");
+                if (payload.Length > 0)
+                {
+                    throw new($"Unknown payload: {payload}");
+                }
             }
 
             if (client.Connected)


### PR DESCRIPTION
Fixes compatibility with the Verify.Go client proxy.