### PR TITLE
Allow defining of CLI apps to be searched via PATH

### DIFF
--- a/src/DiffEngine.Tests/OsSettingsResolverTest.cs
+++ b/src/DiffEngine.Tests/OsSettingsResolverTest.cs
@@ -1,4 +1,6 @@
-﻿public class OsSettingsResolverTest :
+﻿using System.Runtime.InteropServices;
+
+public class OsSettingsResolverTest :
     XunitContextBase
 {
     [Fact]
@@ -15,6 +17,40 @@
         Assert.Equal(@"%ProgramFiles%\Path", paths[0]);
         Assert.Equal(@"%ProgramW6432%\Path", paths[1]);
         Assert.Equal(@"%ProgramFiles(x86)%\Path", paths[2]);
+    }
+
+    [Fact]
+    public void CliDefinition()
+    {
+        var cli = OsSettingsResolver.IsCliDefinition("Path");
+        Assert.Equal(true, cli);
+    }
+
+    [Fact]
+    public void NotCliDefinition()
+    {
+        var path = Path.Join("SomeDirectory", "Path");
+        var cli = OsSettingsResolver.IsCliDefinition(path);
+        Assert.Equal(false, cli);
+    }
+
+    [Fact]
+    public void EnvPath()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var found = OsSettingsResolver.TryFindInEnvPath("cmd.exe", out var filePath);
+            Assert.Equal(true, found);
+            Assert.Equal(@"C:\Windows\System32\cmd.exe", filePath);
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            var found = OsSettingsResolver.TryFindInEnvPath("sh", out var filePath);
+            Assert.Equal(true, found);
+            Assert.NotNull(filePath);
+        }
     }
 
     public OsSettingsResolverTest(ITestOutputHelper output) :

--- a/src/DiffEngine.Tests/OsSettingsResolverTest.cs
+++ b/src/DiffEngine.Tests/OsSettingsResolverTest.cs
@@ -41,7 +41,7 @@ public class OsSettingsResolverTest :
         {
             var found = OsSettingsResolver.TryFindInEnvPath("cmd.exe", out var filePath);
             Assert.Equal(true, found);
-            Assert.Equal(@"C:\Windows\System32\cmd.exe", filePath);
+            Assert.Equal(@"C:\Windows\System32\cmd.exe", filePath, ignoreCase: true);
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)

--- a/src/DiffEngine.Tests/OsSettingsResolverTest.cs
+++ b/src/DiffEngine.Tests/OsSettingsResolverTest.cs
@@ -29,7 +29,7 @@ public class OsSettingsResolverTest :
     [Fact]
     public void NotCliDefinition()
     {
-        var path = Path.Join("SomeDirectory", "Path");
+        var path = Path.Combine("SomeDirectory", "Path");
         var cli = OsSettingsResolver.IsCliDefinition(path);
         Assert.Equal(false, cli);
     }

--- a/src/DiffEngine/WildcardFileFinder.cs
+++ b/src/DiffEngine/WildcardFileFinder.cs
@@ -55,22 +55,6 @@ static class WildcardFileFinder
         return currentRoots;
     }
 
-    public static bool TryFindExe(
-        IEnumerable<string> paths,
-        [NotNullWhen(true)] out string? exePath)
-    {
-        foreach (var path in paths.Distinct(StringComparer.OrdinalIgnoreCase))
-        {
-            if (TryFind(path, out exePath))
-            {
-                return true;
-            }
-        }
-
-        exePath = null;
-        return false;
-    }
-
     public static bool TryFind(
         string path,
         [NotNullWhen(true)] out string? result)


### PR DESCRIPTION
This will allow us to do the following definitions.

```cs
            linux: new(
                TargetLeftArguments,
                TargetRightArguments,
                "vim"),
```

Previous definitions that rely on hard-coded paths should not be affected by these changes.