### PR TITLE
remove bin directories from vscode scanning

### DIFF
--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -751,13 +751,9 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
   * Example target on right arguments: `--diff "tempFile" "targetFile"`
   * Scanned paths:  
     * `%LocalAppData%\Programs\Microsoft VS Code\code.exe`
-    * `%ProgramFiles%\Microsoft VS Code\bin\code.exe`
-    * `%ProgramW6432%\Microsoft VS Code\bin\code.exe`
-    * `%ProgramFiles(x86)%\Microsoft VS Code\bin\code.exe`
     * `%ProgramFiles%\Microsoft VS Code\code.exe`
     * `%ProgramW6432%\Microsoft VS Code\code.exe`
     * `%ProgramFiles(x86)%\Microsoft VS Code\code.exe`
-    * `%UserProfile%\scoop\apps\vscode\current\bin\code.cmd`
     * `%UserProfile%\scoop\apps\vscode\current\code.exe`
 
 #### OSX settings:

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -640,13 +640,9 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
   * Example target on right arguments: `--diff "tempFile" "targetFile"`
   * Scanned paths:  
     * `%LocalAppData%\Programs\Microsoft VS Code\code.exe`
-    * `%ProgramFiles%\Microsoft VS Code\bin\code.exe`
-    * `%ProgramW6432%\Microsoft VS Code\bin\code.exe`
-    * `%ProgramFiles(x86)%\Microsoft VS Code\bin\code.exe`
     * `%ProgramFiles%\Microsoft VS Code\code.exe`
     * `%ProgramW6432%\Microsoft VS Code\code.exe`
     * `%ProgramFiles(x86)%\Microsoft VS Code\code.exe`
-    * `%UserProfile%\scoop\apps\vscode\current\bin\code.cmd`
     * `%UserProfile%\scoop\apps\vscode\current\code.exe`
 
 #### OSX settings:

--- a/src/DiffEngine/Implementation/VsCode.cs
+++ b/src/DiffEngine/Implementation/VsCode.cs
@@ -25,9 +25,7 @@
                 TargetLeftArguments,
                 TargetRightArguments,
                 @"%LocalAppData%\Programs\Microsoft VS Code\code.exe",
-                @"%ProgramFiles%\Microsoft VS Code\bin\code.exe",
                 @"%ProgramFiles%\Microsoft VS Code\code.exe",
-                @"%UserProfile%\scoop\apps\vscode\current\bin\code.cmd",
                 @"%UserProfile%\scoop\apps\vscode\current\code.exe"),
             linux: new(
                 TargetLeftArguments,


### PR DESCRIPTION
since in the current version it is located one level up