### PR TITLE
Rely on path env resolve

### DIFF
--- a/docs/diff-tool.custom.md
+++ b/docs/diff-tool.custom.md
@@ -18,8 +18,8 @@ var resolvedTool = DiffTools.AddTool(
     isMdi: false,
     supportsText: true,
     requiresTarget: true,
-    targetLeftArguments: (tempFile, targetFile) => $"\"{targetFile}\" \"{tempFile}\"",
-    targetRightArguments: (tempFile, targetFile) => $"\"{tempFile}\" \"{targetFile}\"",
+    leftArguments: (tempFile, targetFile) => $"\"{targetFile}\" \"{tempFile}\"",
+    rightArguments: (tempFile, targetFile) => $"\"{tempFile}\" \"{targetFile}\"",
     exePath: diffToolPath,
     binaryExtensions: new[] {"jpg"})!;
 ```
@@ -34,8 +34,8 @@ Add a tool based on existing resolved tool:
 var resolvedTool = DiffTools.AddToolBasedOn(
     DiffTool.VisualStudio,
     name: "MyCustomDiffTool",
-    targetLeftArguments: (temp, target) => $"\"custom args \"{target}\" \"{temp}\"",
-    targetRightArguments: (temp, target) => $"\"custom args \"{temp}\" \"{target}\"")!;
+    leftArguments: (temp, target) => $"\"custom args \"{target}\" \"{temp}\"",
+    rightArguments: (temp, target) => $"\"custom args \"{temp}\" \"{target}\"")!;
 ```
 <sup><a href='/src/DiffEngine.Tests/DiffToolsTest.cs#L63-L71' title='Snippet source file'>snippet source</a> | <a href='#snippet-addtoolbasedon' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
@@ -61,8 +61,8 @@ Alternatively the instance  returned from `AddTool*` can be used to explicitly l
 var resolvedTool = DiffTools.AddToolBasedOn(
     DiffTool.VisualStudio,
     name: "MyCustomDiffTool",
-    targetLeftArguments: (temp, target) => $"\"custom args \"{target}\" \"{temp}\"",
-    targetRightArguments: (temp, target) => $"\"custom args \"{temp}\" \"{target}\"");
+    leftArguments: (temp, target) => $"\"custom args \"{target}\" \"{temp}\"",
+    rightArguments: (temp, target) => $"\"custom args \"{temp}\" \"{target}\"");
 
 await DiffRunner.LaunchAsync(resolvedTool!, "PathToTempFile", "PathToTargetFile");
 ```

--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -137,7 +137,6 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
     * `%ProgramFiles%\Beyond Compare *\BCompare.exe`
     * `%ProgramW6432%\Beyond Compare *\BCompare.exe`
     * `%ProgramFiles(x86)%\Beyond Compare *\BCompare.exe`
-    * `%UserProfile%\scoop\apps\beyondcompare\current\BCompare.exe`
 
 #### OSX settings:
 
@@ -206,7 +205,6 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
     * `%ProgramFiles%\Diffinity\Diffinity.exe`
     * `%ProgramW6432%\Diffinity\Diffinity.exe`
     * `%ProgramFiles(x86)%\Diffinity\Diffinity.exe`
-    * `%UserProfile%\scoop\apps\diffinity\current\Diffinity.exe`
 
 ### [DiffMerge](https://www.sourcegear.com/diffmerge/)
 
@@ -350,18 +348,26 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Supports auto-refresh: False
   * Supports text files: True
 
-#### Notes:
-
-
- * Assumes installed through Chocolatey https://chocolatey.org/packages/neovim/
-
 #### Windows settings:
 
   * Example target on left arguments: `-d "targetFile" "tempFile"`
   * Example target on right arguments: `-d "tempFile" "targetFile"`
   * Scanned paths:  
     * `%PATH%nvim.exe`
-    * `%ChocolateyToolsLocation%\neovim\*\nvim.exe`
+
+#### OSX settings:
+
+  * Example target on left arguments: `-d "targetFile" "tempFile"`
+  * Example target on right arguments: `-d "tempFile" "targetFile"`
+  * Scanned paths:  
+    * `%PATH%nvim`
+
+#### Linux settings:
+
+  * Example target on left arguments: `-d "targetFile" "tempFile"`
+  * Example target on right arguments: `-d "tempFile" "targetFile"`
+  * Scanned paths:  
+    * `%PATH%nvim`
 
 ### [P4MergeImage](https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge)
 
@@ -452,7 +458,6 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
     * `%ProgramFiles(x86)%\JetBrains\JetBrains Rider *\bin\rider64.exe`
     * `%JetBrains Rider%\rider64.exe`
     * `%LOCALAPPDATA%\JetBrains\Toolbox\apps\Rider\*\*\bin\rider64.exe`
-    * `%UserProfile%\scoop\apps\rider\current\IDE\bin\rider64.exe`
 
 #### OSX settings:
 
@@ -787,7 +792,6 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
     * `%ProgramFiles%\Microsoft VS Code\code.exe`
     * `%ProgramW6432%\Microsoft VS Code\code.exe`
     * `%ProgramFiles(x86)%\Microsoft VS Code\code.exe`
-    * `%UserProfile%\scoop\apps\vscode\current\code.exe`
 
 #### OSX settings:
 

--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -135,6 +135,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `/solo /rightreadonly "targetFile" "tempFile"`
   * Example target on right arguments: `/solo /leftreadonly "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%BCompare.exe`
     * `%ProgramFiles%\Beyond Compare *\BCompare.exe`
     * `%ProgramW6432%\Beyond Compare *\BCompare.exe`
     * `%ProgramFiles(x86)%\Beyond Compare *\BCompare.exe`
@@ -144,13 +145,17 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-solo -rightreadonly "targetFile" "tempFile"`
   * Example target on right arguments: `-solo -leftreadonly "tempFile" "targetFile"`
-  * Scanned path: `/Applications/Beyond Compare.app/Contents/MacOS/bcomp`
+  * Scanned paths:  
+    * `%PATH%bcomp`
+    * `/Applications/Beyond Compare.app/Contents/MacOS/bcomp`
 
 #### Linux settings:
 
   * Example target on left arguments: `-solo -rightreadonly "targetFile" "tempFile"`
   * Example target on right arguments: `-solo -leftreadonly "tempFile" "targetFile"`
-  * Scanned path: `/usr/lib/beyondcompare/bcomp`
+  * Scanned paths:  
+    * `%PATH%bcomp`
+    * `/usr/lib/beyondcompare/bcomp`
 
 ### [DeltaWalker](https://www.deltawalker.com/)
 
@@ -170,13 +175,17 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-mi "targetFile" "tempFile"`
   * Example target on right arguments: `-mi "tempFile" "targetFile"`
-  * Scanned path: `C:\Program Files\Deltopia\DeltaWalker\DeltaWalker.exe`
+  * Scanned paths:  
+    * `%PATH%DeltaWalker.exe`
+    * `C:\Program Files\Deltopia\DeltaWalker\DeltaWalker.exe`
 
 #### OSX settings:
 
   * Example target on left arguments: `-mi "targetFile" "tempFile"`
   * Example target on right arguments: `-mi "tempFile" "targetFile"`
-  * Scanned path: `/Applications/DeltaWalker.app/Contents/MacOS/DeltaWalker`
+  * Scanned paths:  
+    * `%PATH%DeltaWalker`
+    * `/Applications/DeltaWalker.app/Contents/MacOS/DeltaWalker`
 
 ### [Diffinity](https://truehumandesign.se/s_diffinity.php)
 
@@ -197,6 +206,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%Diffinity.exe`
     * `%ProgramFiles%\Diffinity\Diffinity.exe`
     * `%ProgramW6432%\Diffinity\Diffinity.exe`
     * `%ProgramFiles(x86)%\Diffinity\Diffinity.exe`
@@ -215,6 +225,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `--nosplash "targetFile" "tempFile"`
   * Example target on right arguments: `--nosplash "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%sgdm.exe`
     * `%ProgramFiles%\SourceGear\Common\DiffMerge\sgdm.exe`
     * `%ProgramW6432%\SourceGear\Common\DiffMerge\sgdm.exe`
     * `%ProgramFiles(x86)%\SourceGear\Common\DiffMerge\sgdm.exe`
@@ -223,13 +234,16 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--nosplash "targetFile" "tempFile"`
   * Example target on right arguments: `--nosplash "tempFile" "targetFile"`
-  * Scanned path: `/Applications/DiffMerge.app/Contents/MacOS/DiffMerge`
+  * Scanned paths:  
+    * `%PATH%DiffMerge`
+    * `/Applications/DiffMerge.app/Contents/MacOS/DiffMerge`
 
 #### Linux settings:
 
   * Example target on left arguments: `--nosplash "targetFile" "tempFile"`
   * Example target on right arguments: `--nosplash "tempFile" "targetFile"`
-  * Scanned path: `/usr/bin/diffmerge`
+  * Scanned paths:  
+    * `%PATH%diffmerge`
 
 ### [ExamDiff](https://www.prestosoft.com/edp_examdiffpro.asp)
 
@@ -251,6 +265,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile" /nh /diffonly /dn1:targetFile /dn2:tempFile`
   * Example target on right arguments: `"tempFile" "targetFile" /nh /diffonly /dn1:tempFile /dn2:targetFile`
   * Scanned paths:  
+    * `%PATH%ExamDiff.exe`
     * `%ProgramFiles%\ExamDiff Pro\ExamDiff.exe`
     * `%ProgramW6432%\ExamDiff Pro\ExamDiff.exe`
     * `%ProgramFiles(x86)%\ExamDiff Pro\ExamDiff.exe`
@@ -277,6 +292,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile" -ge2`
   * Example target on right arguments: `"tempFile" "targetFile" -ge1`
   * Scanned paths:  
+    * `%PATH%guiffy.exe`
     * `%ProgramFiles%\Guiffy\guiffy.exe`
     * `%ProgramW6432%\Guiffy\guiffy.exe`
     * `%ProgramFiles(x86)%\Guiffy\guiffy.exe`
@@ -285,7 +301,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile" "tempFile" -ge2`
   * Example target on right arguments: `"tempFile" "targetFile" -ge1`
-  * Scanned path: `/Applications/Guiffy/guiffyCL.command`
+  * Scanned paths:  
+    * `%PATH%guiffyCL.command`
+    * `/Applications/Guiffy/guiffyCL.command`
 
 ### [Kaleidoscope](https://www.kaleidoscopeapp.com/)
 
@@ -300,7 +318,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/usr/local/bin/ksdiff`
+  * Scanned paths:  
+    * `%PATH%ksdiff`
 
 ### [KDiff3](https://github.com/KDE/kdiff3)
 
@@ -320,6 +339,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile" --cs CreateBakFiles=0`
   * Example target on right arguments: `"tempFile" "targetFile" --cs CreateBakFiles=0`
   * Scanned paths:  
+    * `%PATH%kdiff3.exe`
     * `%ProgramFiles%\KDiff3\kdiff3.exe`
     * `%ProgramW6432%\KDiff3\kdiff3.exe`
     * `%ProgramFiles(x86)%\KDiff3\kdiff3.exe`
@@ -328,7 +348,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile" "tempFile" --cs CreateBakFiles=0`
   * Example target on right arguments: `"tempFile" "targetFile" --cs CreateBakFiles=0`
-  * Scanned path: `/Applications/kdiff3.app/Contents/MacOS/kdiff3`
+  * Scanned paths:  
+    * `%PATH%kdiff3`
+    * `/Applications/kdiff3.app/Contents/MacOS/kdiff3`
 
 ### [Neovim](https://neovim.io/)
 
@@ -347,7 +369,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-d "targetFile" "tempFile"`
   * Example target on right arguments: `-d "tempFile" "targetFile"`
-  * Scanned path: `%ChocolateyToolsLocation%\neovim\*\nvim.exe`
+  * Scanned paths:  
+    * `%PATH%nvim.exe`
+    * `%ChocolateyToolsLocation%\neovim\*\nvim.exe`
 
 ### [P4MergeImage](https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge)
 
@@ -363,6 +387,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%p4merge.exe`
     * `%ProgramFiles%\Perforce\p4merge.exe`
     * `%ProgramW6432%\Perforce\p4merge.exe`
     * `%ProgramFiles(x86)%\Perforce\p4merge.exe`
@@ -371,13 +396,16 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/Applications/p4merge.app/Contents/MacOS/p4merge`
+  * Scanned paths:  
+    * `%PATH%p4merge`
+    * `/Applications/p4merge.app/Contents/MacOS/p4merge`
 
 #### Linux settings:
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/usr/bin/p4merge`
+  * Scanned paths:  
+    * `%PATH%p4merge`
 
 ### [P4MergeText](https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge)
 
@@ -392,6 +420,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `-C utf8-bom "tempFile" "targetFile" "targetFile" "targetFile"`
   * Example target on right arguments: `-C utf8-bom "targetFile" "tempFile" "targetFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%p4merge.exe`
     * `%ProgramFiles%\Perforce\p4merge.exe`
     * `%ProgramW6432%\Perforce\p4merge.exe`
     * `%ProgramFiles(x86)%\Perforce\p4merge.exe`
@@ -400,13 +429,16 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-C utf8-bom "tempFile" "targetFile" "targetFile" "targetFile"`
   * Example target on right arguments: `-C utf8-bom "targetFile" "tempFile" "targetFile" "targetFile"`
-  * Scanned path: `/Applications/p4merge.app/Contents/MacOS/p4merge`
+  * Scanned paths:  
+    * `%PATH%p4merge`
+    * `/Applications/p4merge.app/Contents/MacOS/p4merge`
 
 #### Linux settings:
 
   * Example target on left arguments: `-C utf8-bom "tempFile" "targetFile" "targetFile" "targetFile"`
   * Example target on right arguments: `-C utf8-bom "targetFile" "tempFile" "targetFile" "targetFile"`
-  * Scanned path: `/usr/bin/p4merge`
+  * Scanned paths:  
+    * `%PATH%p4merge`
 
 ### [Rider](https://www.jetbrains.com/rider/)
 
@@ -426,6 +458,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `diff "targetFile" "tempFile"`
   * Example target on right arguments: `diff "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%rider64.exe`
     * `%LOCALAPPDATA%\JetBrains\Installations\Rider*\bin\rider64.exe`
     * `%ProgramFiles%\JetBrains\JetBrains Rider *\bin\rider64.exe`
     * `%ProgramW6432%\JetBrains\JetBrains Rider *\bin\rider64.exe`
@@ -439,6 +472,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `diff "targetFile" "tempFile"`
   * Example target on right arguments: `diff "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%rider`
     * `%HOME%/Library/Application Support/JetBrains/Toolbox/apps/Rider/*/*/Rider EAP.app/Contents/MacOS/rider`
     * `%HOME%/Library/Application Support/JetBrains/Toolbox/apps/Rider/*/*/Rider.app/Contents/MacOS/rider`
     * `/Applications/Rider EAP.app/Contents/MacOS/rider`
@@ -449,6 +483,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `diff "targetFile" "tempFile"`
   * Example target on right arguments: `diff "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%rider.sh`
     * `%HOME%/.local/share/JetBrains/Toolbox/apps/Rider/*/*/bin/rider.sh`
     * `/opt/jetbrains/rider/bin/rider.sh`
     * `/usr/share/rider/bin/rider.sh`
@@ -465,7 +500,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/Applications/TkDiff.app/Contents/MacOS/tkdiff`
+  * Scanned paths:  
+    * `%PATH%tkdiff`
+    * `/Applications/TkDiff.app/Contents/MacOS/tkdiff`
 
 ### [TortoiseGitMerge](https://tortoisegit.org/docs/tortoisegitmerge/)
 
@@ -480,6 +517,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%TortoiseGitMerge.exe`
     * `%ProgramFiles%\TortoiseGit\bin\TortoiseGitMerge.exe`
     * `%ProgramW6432%\TortoiseGit\bin\TortoiseGitMerge.exe`
     * `%ProgramFiles(x86)%\TortoiseGit\bin\TortoiseGitMerge.exe`
@@ -498,6 +536,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `/left:"targetFile" /right:"tempFile"`
   * Example target on right arguments: `/left:"tempFile" /right:"targetFile"`
   * Scanned paths:  
+    * `%PATH%TortoiseIDiff.exe`
     * `%ProgramFiles%\TortoiseSVN\bin\TortoiseIDiff.exe`
     * `%ProgramW6432%\TortoiseSVN\bin\TortoiseIDiff.exe`
     * `%ProgramFiles(x86)%\TortoiseSVN\bin\TortoiseIDiff.exe`
@@ -515,6 +554,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%TortoiseMerge.exe`
     * `%ProgramFiles%\TortoiseSVN\bin\TortoiseMerge.exe`
     * `%ProgramW6432%\TortoiseSVN\bin\TortoiseMerge.exe`
     * `%ProgramFiles(x86)%\TortoiseSVN\bin\TortoiseMerge.exe`
@@ -541,6 +581,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `-d "targetFile" "tempFile" -c "setl autoread | setl nobackup | set noswapfile"`
   * Example target on right arguments: `-d "tempFile" "targetFile" -c "setl autoread | setl nobackup | set noswapfile"`
   * Scanned paths:  
+    * `%PATH%vim.exe`
     * `%ProgramFiles%\Vim\*\vim.exe`
     * `%ProgramW6432%\Vim\*\vim.exe`
     * `%ProgramFiles(x86)%\Vim\*\vim.exe`
@@ -549,7 +590,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-d "targetFile" "tempFile" -c "setl autoread | setl nobackup | set noswapfile"`
   * Example target on right arguments: `-d "tempFile" "targetFile" -c "setl autoread | setl nobackup | set noswapfile"`
-  * Scanned path: `/Applications/MacVim.app/Contents/bin/mvim`
+  * Scanned paths:  
+    * `%PATH%mvim`
+    * `/Applications/MacVim.app/Contents/bin/mvim`
 
 ### [WinMerge](https://winmerge.org/)
 
@@ -574,6 +617,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `/u /wl /e "targetFile" "tempFile" /dl "targetFile" /dr "tempFile"`
   * Example target on right arguments: `/u /wl /e "tempFile" "targetFile" /dl "tempFile" /dr "targetFile"`
   * Scanned paths:  
+    * `%PATH%WinMergeU.exe`
     * `%ProgramFiles%\WinMerge\WinMergeU.exe`
     * `%ProgramW6432%\WinMerge\WinMergeU.exe`
     * `%ProgramFiles(x86)%\WinMerge\WinMergeU.exe`
@@ -604,6 +648,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `/nowait "targetFile" "tempFile"`
   * Example target on right arguments: `/nowait "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%Compare.exe`
     * `%ProgramFiles%\Araxis\Araxis Merge\Compare.exe`
     * `%ProgramW6432%\Araxis\Araxis Merge\Compare.exe`
     * `%ProgramFiles(x86)%\Araxis\Araxis Merge\Compare.exe`
@@ -612,7 +657,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-nowait "targetFile" "tempFile"`
   * Example target on right arguments: `-nowait "tempFile" "targetFile"`
-  * Scanned path: `/Applications/Araxis Merge.app/Contents/Utilities/compare`
+  * Scanned paths:  
+    * `%PATH%compare`
+    * `/Applications/Araxis Merge.app/Contents/Utilities/compare`
 
 ### [CodeCompare](https://www.devart.com/codecompare/)
 
@@ -632,6 +679,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%CodeCompare.exe`
     * `%ProgramFiles%\Devart\Code Compare\CodeCompare.exe`
     * `%ProgramW6432%\Devart\Code Compare\CodeCompare.exe`
     * `%ProgramFiles(x86)%\Devart\Code Compare\CodeCompare.exe`
@@ -653,6 +701,7 @@ While Meld is not MDI, it is treated as MDI since it uses a single shared proces
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%meld.exe`
     * `%LOCALAPPDATA%\Programs\Meld\meld.exe`
     * `%ProgramFiles%\Meld\meld.exe`
     * `%ProgramW6432%\Meld\meld.exe`
@@ -662,13 +711,16 @@ While Meld is not MDI, it is treated as MDI since it uses a single shared proces
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/Applications/meld.app/Contents/MacOS/meld`
+  * Scanned paths:  
+    * `%PATH%meld`
+    * `/Applications/meld.app/Contents/MacOS/meld`
 
 #### Linux settings:
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/usr/bin/meld`
+  * Scanned paths:  
+    * `%PATH%meld`
 
 ### [SublimeMerge](https://www.sublimemerge.com/)
 
@@ -687,6 +739,7 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
   * Example target on left arguments: `mergetool "targetFile" "tempFile"`
   * Example target on right arguments: `mergetool "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%smerge.exe`
     * `%ProgramFiles%\Sublime Merge\smerge.exe`
     * `%ProgramW6432%\Sublime Merge\smerge.exe`
     * `%ProgramFiles(x86)%\Sublime Merge\smerge.exe`
@@ -695,13 +748,16 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
 
   * Example target on left arguments: `mergetool "targetFile" "tempFile"`
   * Example target on right arguments: `mergetool "tempFile" "targetFile"`
-  * Scanned path: `/Applications/smerge.app/Contents/MacOS/smerge`
+  * Scanned paths:  
+    * `%PATH%smerge`
+    * `/Applications/smerge.app/Contents/MacOS/smerge`
 
 #### Linux settings:
 
   * Example target on left arguments: `mergetool "targetFile" "tempFile"`
   * Example target on right arguments: `mergetool "tempFile" "targetFile"`
-  * Scanned path: `/usr/bin/smerge`
+  * Scanned paths:  
+    * `%PATH%smerge`
 
 ### [VisualStudio](https://docs.microsoft.com/en-us/visualstudio/ide/reference/diff)
 
@@ -716,6 +772,7 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
   * Example target on left arguments: `/diff "targetFile" "tempFile" "targetFile" "tempFile"`
   * Example target on right arguments: `/diff "tempFile" "targetFile" "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%devenv.exe`
     * `%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\IDE\devenv.exe`
     * `%ProgramW6432%\Microsoft Visual Studio\2022\Preview\Common7\IDE\devenv.exe`
     * `%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Preview\Common7\IDE\devenv.exe`
@@ -750,6 +807,7 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
   * Example target on left arguments: `--diff "targetFile" "tempFile"`
   * Example target on right arguments: `--diff "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%code.exe`
     * `%LocalAppData%\Programs\Microsoft VS Code\code.exe`
     * `%ProgramFiles%\Microsoft VS Code\code.exe`
     * `%ProgramW6432%\Microsoft VS Code\code.exe`
@@ -760,12 +818,13 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
 
   * Example target on left arguments: `--diff "targetFile" "tempFile"`
   * Example target on right arguments: `--diff "tempFile" "targetFile"`
-  * Scanned path: `/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code`
+  * Scanned paths:  
+    * `%PATH%code`
+    * `/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code`
 
 #### Linux settings:
 
   * Example target on left arguments: `--diff "targetFile" "tempFile"`
   * Example target on right arguments: `--diff "tempFile" "targetFile"`
   * Scanned paths:  
-    * `/usr/local/bin/code`
-    * `/usr/bin/code` <!-- endInclude -->
+    * `%PATH%code` <!-- endInclude -->

--- a/docs/diff-tool.order.md
+++ b/docs/diff-tool.order.md
@@ -27,7 +27,7 @@ To change this file edit the source file and then run MarkdownSnippets.
  * **[P4MergeImage](/docs/diff-tool.md#p4mergeimage)** Win/OSX/Linux (Cost: Free)
  * **[Rider](/docs/diff-tool.md#rider)** Win/OSX/Linux (Cost: Paid with free option for OSS)
  * **[Vim](/docs/diff-tool.md#vim)** Win/OSX (Cost: Free with option to donate)
- * **[Neovim](/docs/diff-tool.md#neovim)** Win (Cost: Free with option to sponsor)
+ * **[Neovim](/docs/diff-tool.md#neovim)** Win/OSX/Linux (Cost: Free with option to sponsor)
  * **[AraxisMerge](/docs/diff-tool.md#araxismerge)** Win/OSX (Cost: Paid)
  * **[Meld](/docs/diff-tool.md#meld)** Win/OSX/Linux (Cost: Free)
  * **[SublimeMerge](/docs/diff-tool.md#sublimemerge)** Win/OSX/Linux (Cost: Paid)

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ DiffEngine manages launching and cleanup of diff tools. It is designed to be use
  * **[P4MergeImage](/docs/diff-tool.md#p4mergeimage)** Win/OSX/Linux (Cost: Free)
  * **[Rider](/docs/diff-tool.md#rider)** Win/OSX/Linux (Cost: Paid with free option for OSS)
  * **[Vim](/docs/diff-tool.md#vim)** Win/OSX (Cost: Free with option to donate)
- * **[Neovim](/docs/diff-tool.md#neovim)** Win (Cost: Free with option to sponsor)
+ * **[Neovim](/docs/diff-tool.md#neovim)** Win/OSX/Linux (Cost: Free with option to sponsor)
  * **[AraxisMerge](/docs/diff-tool.md#araxismerge)** Win/OSX (Cost: Paid)
  * **[Meld](/docs/diff-tool.md#meld)** Win/OSX/Linux (Cost: Free)
  * **[SublimeMerge](/docs/diff-tool.md#sublimemerge)** Win/OSX/Linux (Cost: Paid)

--- a/src/DiffEngine.Tests/DefinitionsTest.cs
+++ b/src/DiffEngine.Tests/DefinitionsTest.cs
@@ -109,7 +109,7 @@
 
         if (tool.BinaryExtensions.Any())
         {
-            writer.WriteLine("  * Supported binaries: " + string.Join(", ", tool.BinaryExtensions));
+            writer.WriteLine($"  * Supported binaries: {string.Join(", ", tool.BinaryExtensions)}");
         }
 
         if (tool.Notes != null)

--- a/src/DiffEngine.Tests/DefinitionsTest.cs
+++ b/src/DiffEngine.Tests/DefinitionsTest.cs
@@ -171,19 +171,13 @@
 
     static void WritePaths(string exeName, TextWriter writer, IReadOnlyCollection<string> paths)
     {
-        if (paths.Count > 1)
+        writer.WriteLine("""
+                           * Scanned paths:  
+                         """);
+        writer.WriteLine($"    * `%PATH%{exeName}`");
+        foreach (var path in paths)
         {
-            writer.WriteLine("""
-                               * Scanned paths:  
-                             """);
-            foreach (var path in paths)
-            {
-                writer.WriteLine($"    * `{path}{exeName}`");
-            }
-        }
-        else
-        {
-            writer.WriteLine($"  * Scanned path: `{paths.Single()}{exeName}`");
+            writer.WriteLine($"    * `{path}{exeName}`");
         }
     }
 

--- a/src/DiffEngine.Tests/defaultOrder.include.md
+++ b/src/DiffEngine.Tests/defaultOrder.include.md
@@ -15,7 +15,7 @@
  * **[P4MergeImage](/docs/diff-tool.md#p4mergeimage)** Win/OSX/Linux (Cost: Free)
  * **[Rider](/docs/diff-tool.md#rider)** Win/OSX/Linux (Cost: Paid with free option for OSS)
  * **[Vim](/docs/diff-tool.md#vim)** Win/OSX (Cost: Free with option to donate)
- * **[Neovim](/docs/diff-tool.md#neovim)** Win (Cost: Free with option to sponsor)
+ * **[Neovim](/docs/diff-tool.md#neovim)** Win/OSX/Linux (Cost: Free with option to sponsor)
  * **[AraxisMerge](/docs/diff-tool.md#araxismerge)** Win/OSX (Cost: Paid)
  * **[Meld](/docs/diff-tool.md#meld)** Win/OSX/Linux (Cost: Free)
  * **[SublimeMerge](/docs/diff-tool.md#sublimemerge)** Win/OSX/Linux (Cost: Paid)

--- a/src/DiffEngine.Tests/diffToolList.include.md
+++ b/src/DiffEngine.Tests/diffToolList.include.md
@@ -15,7 +15,7 @@
  * **[P4MergeImage](/docs/diff-tool.md#p4mergeimage)** Win/OSX/Linux (Cost: Free)
  * **[Rider](/docs/diff-tool.md#rider)** Win/OSX/Linux (Cost: Paid with free option for OSS)
  * **[Vim](/docs/diff-tool.md#vim)** Win/OSX (Cost: Free with option to donate)
- * **[Neovim](/docs/diff-tool.md#neovim)** Win (Cost: Free with option to sponsor)
+ * **[Neovim](/docs/diff-tool.md#neovim)** Win/OSX/Linux (Cost: Free with option to sponsor)
  * **[AraxisMerge](/docs/diff-tool.md#araxismerge)** Win/OSX (Cost: Paid)
  * **[Meld](/docs/diff-tool.md#meld)** Win/OSX/Linux (Cost: Free)
  * **[SublimeMerge](/docs/diff-tool.md#sublimemerge)** Win/OSX/Linux (Cost: Paid)

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -26,7 +26,6 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
     * `%ProgramFiles%\Beyond Compare *\BCompare.exe`
     * `%ProgramW6432%\Beyond Compare *\BCompare.exe`
     * `%ProgramFiles(x86)%\Beyond Compare *\BCompare.exe`
-    * `%UserProfile%\scoop\apps\beyondcompare\current\BCompare.exe`
 
 #### OSX settings:
 
@@ -95,7 +94,6 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
     * `%ProgramFiles%\Diffinity\Diffinity.exe`
     * `%ProgramW6432%\Diffinity\Diffinity.exe`
     * `%ProgramFiles(x86)%\Diffinity\Diffinity.exe`
-    * `%UserProfile%\scoop\apps\diffinity\current\Diffinity.exe`
 
 ### [DiffMerge](https://www.sourcegear.com/diffmerge/)
 
@@ -239,18 +237,26 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Supports auto-refresh: False
   * Supports text files: True
 
-#### Notes:
-
-
- * Assumes installed through Chocolatey https://chocolatey.org/packages/neovim/
-
 #### Windows settings:
 
   * Example target on left arguments: `-d "targetFile" "tempFile"`
   * Example target on right arguments: `-d "tempFile" "targetFile"`
   * Scanned paths:  
     * `%PATH%nvim.exe`
-    * `%ChocolateyToolsLocation%\neovim\*\nvim.exe`
+
+#### OSX settings:
+
+  * Example target on left arguments: `-d "targetFile" "tempFile"`
+  * Example target on right arguments: `-d "tempFile" "targetFile"`
+  * Scanned paths:  
+    * `%PATH%nvim`
+
+#### Linux settings:
+
+  * Example target on left arguments: `-d "targetFile" "tempFile"`
+  * Example target on right arguments: `-d "tempFile" "targetFile"`
+  * Scanned paths:  
+    * `%PATH%nvim`
 
 ### [P4MergeImage](https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge)
 
@@ -341,7 +347,6 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
     * `%ProgramFiles(x86)%\JetBrains\JetBrains Rider *\bin\rider64.exe`
     * `%JetBrains Rider%\rider64.exe`
     * `%LOCALAPPDATA%\JetBrains\Toolbox\apps\Rider\*\*\bin\rider64.exe`
-    * `%UserProfile%\scoop\apps\rider\current\IDE\bin\rider64.exe`
 
 #### OSX settings:
 
@@ -676,7 +681,6 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
     * `%ProgramFiles%\Microsoft VS Code\code.exe`
     * `%ProgramW6432%\Microsoft VS Code\code.exe`
     * `%ProgramFiles(x86)%\Microsoft VS Code\code.exe`
-    * `%UserProfile%\scoop\apps\vscode\current\code.exe`
 
 #### OSX settings:
 

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -24,6 +24,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `/solo /rightreadonly "targetFile" "tempFile"`
   * Example target on right arguments: `/solo /leftreadonly "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%BCompare.exe`
     * `%ProgramFiles%\Beyond Compare *\BCompare.exe`
     * `%ProgramW6432%\Beyond Compare *\BCompare.exe`
     * `%ProgramFiles(x86)%\Beyond Compare *\BCompare.exe`
@@ -33,13 +34,17 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-solo -rightreadonly "targetFile" "tempFile"`
   * Example target on right arguments: `-solo -leftreadonly "tempFile" "targetFile"`
-  * Scanned path: `/Applications/Beyond Compare.app/Contents/MacOS/bcomp`
+  * Scanned paths:  
+    * `%PATH%bcomp`
+    * `/Applications/Beyond Compare.app/Contents/MacOS/bcomp`
 
 #### Linux settings:
 
   * Example target on left arguments: `-solo -rightreadonly "targetFile" "tempFile"`
   * Example target on right arguments: `-solo -leftreadonly "tempFile" "targetFile"`
-  * Scanned path: `/usr/lib/beyondcompare/bcomp`
+  * Scanned paths:  
+    * `%PATH%bcomp`
+    * `/usr/lib/beyondcompare/bcomp`
 
 ### [DeltaWalker](https://www.deltawalker.com/)
 
@@ -59,13 +64,17 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-mi "targetFile" "tempFile"`
   * Example target on right arguments: `-mi "tempFile" "targetFile"`
-  * Scanned path: `C:\Program Files\Deltopia\DeltaWalker\DeltaWalker.exe`
+  * Scanned paths:  
+    * `%PATH%DeltaWalker.exe`
+    * `C:\Program Files\Deltopia\DeltaWalker\DeltaWalker.exe`
 
 #### OSX settings:
 
   * Example target on left arguments: `-mi "targetFile" "tempFile"`
   * Example target on right arguments: `-mi "tempFile" "targetFile"`
-  * Scanned path: `/Applications/DeltaWalker.app/Contents/MacOS/DeltaWalker`
+  * Scanned paths:  
+    * `%PATH%DeltaWalker`
+    * `/Applications/DeltaWalker.app/Contents/MacOS/DeltaWalker`
 
 ### [Diffinity](https://truehumandesign.se/s_diffinity.php)
 
@@ -86,6 +95,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%Diffinity.exe`
     * `%ProgramFiles%\Diffinity\Diffinity.exe`
     * `%ProgramW6432%\Diffinity\Diffinity.exe`
     * `%ProgramFiles(x86)%\Diffinity\Diffinity.exe`
@@ -104,6 +114,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `--nosplash "targetFile" "tempFile"`
   * Example target on right arguments: `--nosplash "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%sgdm.exe`
     * `%ProgramFiles%\SourceGear\Common\DiffMerge\sgdm.exe`
     * `%ProgramW6432%\SourceGear\Common\DiffMerge\sgdm.exe`
     * `%ProgramFiles(x86)%\SourceGear\Common\DiffMerge\sgdm.exe`
@@ -112,13 +123,16 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--nosplash "targetFile" "tempFile"`
   * Example target on right arguments: `--nosplash "tempFile" "targetFile"`
-  * Scanned path: `/Applications/DiffMerge.app/Contents/MacOS/DiffMerge`
+  * Scanned paths:  
+    * `%PATH%DiffMerge`
+    * `/Applications/DiffMerge.app/Contents/MacOS/DiffMerge`
 
 #### Linux settings:
 
   * Example target on left arguments: `--nosplash "targetFile" "tempFile"`
   * Example target on right arguments: `--nosplash "tempFile" "targetFile"`
-  * Scanned path: `/usr/bin/diffmerge`
+  * Scanned paths:  
+    * `%PATH%diffmerge`
 
 ### [ExamDiff](https://www.prestosoft.com/edp_examdiffpro.asp)
 
@@ -140,6 +154,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile" /nh /diffonly /dn1:targetFile /dn2:tempFile`
   * Example target on right arguments: `"tempFile" "targetFile" /nh /diffonly /dn1:tempFile /dn2:targetFile`
   * Scanned paths:  
+    * `%PATH%ExamDiff.exe`
     * `%ProgramFiles%\ExamDiff Pro\ExamDiff.exe`
     * `%ProgramW6432%\ExamDiff Pro\ExamDiff.exe`
     * `%ProgramFiles(x86)%\ExamDiff Pro\ExamDiff.exe`
@@ -166,6 +181,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile" -ge2`
   * Example target on right arguments: `"tempFile" "targetFile" -ge1`
   * Scanned paths:  
+    * `%PATH%guiffy.exe`
     * `%ProgramFiles%\Guiffy\guiffy.exe`
     * `%ProgramW6432%\Guiffy\guiffy.exe`
     * `%ProgramFiles(x86)%\Guiffy\guiffy.exe`
@@ -174,7 +190,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile" "tempFile" -ge2`
   * Example target on right arguments: `"tempFile" "targetFile" -ge1`
-  * Scanned path: `/Applications/Guiffy/guiffyCL.command`
+  * Scanned paths:  
+    * `%PATH%guiffyCL.command`
+    * `/Applications/Guiffy/guiffyCL.command`
 
 ### [Kaleidoscope](https://www.kaleidoscopeapp.com/)
 
@@ -189,7 +207,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/usr/local/bin/ksdiff`
+  * Scanned paths:  
+    * `%PATH%ksdiff`
 
 ### [KDiff3](https://github.com/KDE/kdiff3)
 
@@ -209,6 +228,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile" --cs CreateBakFiles=0`
   * Example target on right arguments: `"tempFile" "targetFile" --cs CreateBakFiles=0`
   * Scanned paths:  
+    * `%PATH%kdiff3.exe`
     * `%ProgramFiles%\KDiff3\kdiff3.exe`
     * `%ProgramW6432%\KDiff3\kdiff3.exe`
     * `%ProgramFiles(x86)%\KDiff3\kdiff3.exe`
@@ -217,7 +237,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile" "tempFile" --cs CreateBakFiles=0`
   * Example target on right arguments: `"tempFile" "targetFile" --cs CreateBakFiles=0`
-  * Scanned path: `/Applications/kdiff3.app/Contents/MacOS/kdiff3`
+  * Scanned paths:  
+    * `%PATH%kdiff3`
+    * `/Applications/kdiff3.app/Contents/MacOS/kdiff3`
 
 ### [Neovim](https://neovim.io/)
 
@@ -236,7 +258,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-d "targetFile" "tempFile"`
   * Example target on right arguments: `-d "tempFile" "targetFile"`
-  * Scanned path: `%ChocolateyToolsLocation%\neovim\*\nvim.exe`
+  * Scanned paths:  
+    * `%PATH%nvim.exe`
+    * `%ChocolateyToolsLocation%\neovim\*\nvim.exe`
 
 ### [P4MergeImage](https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge)
 
@@ -252,6 +276,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%p4merge.exe`
     * `%ProgramFiles%\Perforce\p4merge.exe`
     * `%ProgramW6432%\Perforce\p4merge.exe`
     * `%ProgramFiles(x86)%\Perforce\p4merge.exe`
@@ -260,13 +285,16 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/Applications/p4merge.app/Contents/MacOS/p4merge`
+  * Scanned paths:  
+    * `%PATH%p4merge`
+    * `/Applications/p4merge.app/Contents/MacOS/p4merge`
 
 #### Linux settings:
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/usr/bin/p4merge`
+  * Scanned paths:  
+    * `%PATH%p4merge`
 
 ### [P4MergeText](https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge)
 
@@ -281,6 +309,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `-C utf8-bom "tempFile" "targetFile" "targetFile" "targetFile"`
   * Example target on right arguments: `-C utf8-bom "targetFile" "tempFile" "targetFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%p4merge.exe`
     * `%ProgramFiles%\Perforce\p4merge.exe`
     * `%ProgramW6432%\Perforce\p4merge.exe`
     * `%ProgramFiles(x86)%\Perforce\p4merge.exe`
@@ -289,13 +318,16 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-C utf8-bom "tempFile" "targetFile" "targetFile" "targetFile"`
   * Example target on right arguments: `-C utf8-bom "targetFile" "tempFile" "targetFile" "targetFile"`
-  * Scanned path: `/Applications/p4merge.app/Contents/MacOS/p4merge`
+  * Scanned paths:  
+    * `%PATH%p4merge`
+    * `/Applications/p4merge.app/Contents/MacOS/p4merge`
 
 #### Linux settings:
 
   * Example target on left arguments: `-C utf8-bom "tempFile" "targetFile" "targetFile" "targetFile"`
   * Example target on right arguments: `-C utf8-bom "targetFile" "tempFile" "targetFile" "targetFile"`
-  * Scanned path: `/usr/bin/p4merge`
+  * Scanned paths:  
+    * `%PATH%p4merge`
 
 ### [Rider](https://www.jetbrains.com/rider/)
 
@@ -315,6 +347,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `diff "targetFile" "tempFile"`
   * Example target on right arguments: `diff "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%rider64.exe`
     * `%LOCALAPPDATA%\JetBrains\Installations\Rider*\bin\rider64.exe`
     * `%ProgramFiles%\JetBrains\JetBrains Rider *\bin\rider64.exe`
     * `%ProgramW6432%\JetBrains\JetBrains Rider *\bin\rider64.exe`
@@ -328,6 +361,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `diff "targetFile" "tempFile"`
   * Example target on right arguments: `diff "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%rider`
     * `%HOME%/Library/Application Support/JetBrains/Toolbox/apps/Rider/*/*/Rider EAP.app/Contents/MacOS/rider`
     * `%HOME%/Library/Application Support/JetBrains/Toolbox/apps/Rider/*/*/Rider.app/Contents/MacOS/rider`
     * `/Applications/Rider EAP.app/Contents/MacOS/rider`
@@ -338,6 +372,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `diff "targetFile" "tempFile"`
   * Example target on right arguments: `diff "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%rider.sh`
     * `%HOME%/.local/share/JetBrains/Toolbox/apps/Rider/*/*/bin/rider.sh`
     * `/opt/jetbrains/rider/bin/rider.sh`
     * `/usr/share/rider/bin/rider.sh`
@@ -354,7 +389,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/Applications/TkDiff.app/Contents/MacOS/tkdiff`
+  * Scanned paths:  
+    * `%PATH%tkdiff`
+    * `/Applications/TkDiff.app/Contents/MacOS/tkdiff`
 
 ### [TortoiseGitMerge](https://tortoisegit.org/docs/tortoisegitmerge/)
 
@@ -369,6 +406,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%TortoiseGitMerge.exe`
     * `%ProgramFiles%\TortoiseGit\bin\TortoiseGitMerge.exe`
     * `%ProgramW6432%\TortoiseGit\bin\TortoiseGitMerge.exe`
     * `%ProgramFiles(x86)%\TortoiseGit\bin\TortoiseGitMerge.exe`
@@ -387,6 +425,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `/left:"targetFile" /right:"tempFile"`
   * Example target on right arguments: `/left:"tempFile" /right:"targetFile"`
   * Scanned paths:  
+    * `%PATH%TortoiseIDiff.exe`
     * `%ProgramFiles%\TortoiseSVN\bin\TortoiseIDiff.exe`
     * `%ProgramW6432%\TortoiseSVN\bin\TortoiseIDiff.exe`
     * `%ProgramFiles(x86)%\TortoiseSVN\bin\TortoiseIDiff.exe`
@@ -404,6 +443,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%TortoiseMerge.exe`
     * `%ProgramFiles%\TortoiseSVN\bin\TortoiseMerge.exe`
     * `%ProgramW6432%\TortoiseSVN\bin\TortoiseMerge.exe`
     * `%ProgramFiles(x86)%\TortoiseSVN\bin\TortoiseMerge.exe`
@@ -430,6 +470,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `-d "targetFile" "tempFile" -c "setl autoread | setl nobackup | set noswapfile"`
   * Example target on right arguments: `-d "tempFile" "targetFile" -c "setl autoread | setl nobackup | set noswapfile"`
   * Scanned paths:  
+    * `%PATH%vim.exe`
     * `%ProgramFiles%\Vim\*\vim.exe`
     * `%ProgramW6432%\Vim\*\vim.exe`
     * `%ProgramFiles(x86)%\Vim\*\vim.exe`
@@ -438,7 +479,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-d "targetFile" "tempFile" -c "setl autoread | setl nobackup | set noswapfile"`
   * Example target on right arguments: `-d "tempFile" "targetFile" -c "setl autoread | setl nobackup | set noswapfile"`
-  * Scanned path: `/Applications/MacVim.app/Contents/bin/mvim`
+  * Scanned paths:  
+    * `%PATH%mvim`
+    * `/Applications/MacVim.app/Contents/bin/mvim`
 
 ### [WinMerge](https://winmerge.org/)
 
@@ -463,6 +506,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `/u /wl /e "targetFile" "tempFile" /dl "targetFile" /dr "tempFile"`
   * Example target on right arguments: `/u /wl /e "tempFile" "targetFile" /dl "tempFile" /dr "targetFile"`
   * Scanned paths:  
+    * `%PATH%WinMergeU.exe`
     * `%ProgramFiles%\WinMerge\WinMergeU.exe`
     * `%ProgramW6432%\WinMerge\WinMergeU.exe`
     * `%ProgramFiles(x86)%\WinMerge\WinMergeU.exe`
@@ -493,6 +537,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `/nowait "targetFile" "tempFile"`
   * Example target on right arguments: `/nowait "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%Compare.exe`
     * `%ProgramFiles%\Araxis\Araxis Merge\Compare.exe`
     * `%ProgramW6432%\Araxis\Araxis Merge\Compare.exe`
     * `%ProgramFiles(x86)%\Araxis\Araxis Merge\Compare.exe`
@@ -501,7 +546,9 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-nowait "targetFile" "tempFile"`
   * Example target on right arguments: `-nowait "tempFile" "targetFile"`
-  * Scanned path: `/Applications/Araxis Merge.app/Contents/Utilities/compare`
+  * Scanned paths:  
+    * `%PATH%compare`
+    * `/Applications/Araxis Merge.app/Contents/Utilities/compare`
 
 ### [CodeCompare](https://www.devart.com/codecompare/)
 
@@ -521,6 +568,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%CodeCompare.exe`
     * `%ProgramFiles%\Devart\Code Compare\CodeCompare.exe`
     * `%ProgramW6432%\Devart\Code Compare\CodeCompare.exe`
     * `%ProgramFiles(x86)%\Devart\Code Compare\CodeCompare.exe`
@@ -542,6 +590,7 @@ While Meld is not MDI, it is treated as MDI since it uses a single shared proces
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%meld.exe`
     * `%LOCALAPPDATA%\Programs\Meld\meld.exe`
     * `%ProgramFiles%\Meld\meld.exe`
     * `%ProgramW6432%\Meld\meld.exe`
@@ -551,13 +600,16 @@ While Meld is not MDI, it is treated as MDI since it uses a single shared proces
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/Applications/meld.app/Contents/MacOS/meld`
+  * Scanned paths:  
+    * `%PATH%meld`
+    * `/Applications/meld.app/Contents/MacOS/meld`
 
 #### Linux settings:
 
   * Example target on left arguments: `"targetFile" "tempFile"`
   * Example target on right arguments: `"tempFile" "targetFile"`
-  * Scanned path: `/usr/bin/meld`
+  * Scanned paths:  
+    * `%PATH%meld`
 
 ### [SublimeMerge](https://www.sublimemerge.com/)
 
@@ -576,6 +628,7 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
   * Example target on left arguments: `mergetool "targetFile" "tempFile"`
   * Example target on right arguments: `mergetool "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%smerge.exe`
     * `%ProgramFiles%\Sublime Merge\smerge.exe`
     * `%ProgramW6432%\Sublime Merge\smerge.exe`
     * `%ProgramFiles(x86)%\Sublime Merge\smerge.exe`
@@ -584,13 +637,16 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
 
   * Example target on left arguments: `mergetool "targetFile" "tempFile"`
   * Example target on right arguments: `mergetool "tempFile" "targetFile"`
-  * Scanned path: `/Applications/smerge.app/Contents/MacOS/smerge`
+  * Scanned paths:  
+    * `%PATH%smerge`
+    * `/Applications/smerge.app/Contents/MacOS/smerge`
 
 #### Linux settings:
 
   * Example target on left arguments: `mergetool "targetFile" "tempFile"`
   * Example target on right arguments: `mergetool "tempFile" "targetFile"`
-  * Scanned path: `/usr/bin/smerge`
+  * Scanned paths:  
+    * `%PATH%smerge`
 
 ### [VisualStudio](https://docs.microsoft.com/en-us/visualstudio/ide/reference/diff)
 
@@ -605,6 +661,7 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
   * Example target on left arguments: `/diff "targetFile" "tempFile" "targetFile" "tempFile"`
   * Example target on right arguments: `/diff "tempFile" "targetFile" "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%devenv.exe`
     * `%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\IDE\devenv.exe`
     * `%ProgramW6432%\Microsoft Visual Studio\2022\Preview\Common7\IDE\devenv.exe`
     * `%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Preview\Common7\IDE\devenv.exe`
@@ -639,6 +696,7 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
   * Example target on left arguments: `--diff "targetFile" "tempFile"`
   * Example target on right arguments: `--diff "tempFile" "targetFile"`
   * Scanned paths:  
+    * `%PATH%code.exe`
     * `%LocalAppData%\Programs\Microsoft VS Code\code.exe`
     * `%ProgramFiles%\Microsoft VS Code\code.exe`
     * `%ProgramW6432%\Microsoft VS Code\code.exe`
@@ -649,12 +707,13 @@ While SublimeMerge is not MDI, it is treated as MDI since it uses a single share
 
   * Example target on left arguments: `--diff "targetFile" "tempFile"`
   * Example target on right arguments: `--diff "tempFile" "targetFile"`
-  * Scanned path: `/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code`
+  * Scanned paths:  
+    * `%PATH%code`
+    * `/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code`
 
 #### Linux settings:
 
   * Example target on left arguments: `--diff "targetFile" "tempFile"`
   * Example target on right arguments: `--diff "tempFile" "targetFile"`
   * Scanned paths:  
-    * `/usr/local/bin/code`
-    * `/usr/bin/code`
+    * `%PATH%code`

--- a/src/DiffEngine/Implementation/BeyondCompare.cs
+++ b/src/DiffEngine/Implementation/BeyondCompare.cs
@@ -49,8 +49,7 @@
                 "BCompare.exe",
                 LeftWindowsArguments,
                 RightWindowsArguments,
-                @"%ProgramFiles%\Beyond Compare *\",
-                @"%UserProfile%\scoop\apps\beyondcompare\current\"),
+                @"%ProgramFiles%\Beyond Compare *\"),
             linux: new(
                 "bcomp",
                 LeftOsxLinuxArguments,

--- a/src/DiffEngine/Implementation/DiffMerge.cs
+++ b/src/DiffEngine/Implementation/DiffMerge.cs
@@ -29,8 +29,7 @@
             linux: new(
                 "diffmerge",
                 LeftArguments,
-                RightArguments,
-                "/usr/bin/"),
+                RightArguments),
             osx: new(
                 "DiffMerge",
                 LeftArguments,

--- a/src/DiffEngine/Implementation/Diffinity.cs
+++ b/src/DiffEngine/Implementation/Diffinity.cs
@@ -25,8 +25,7 @@
                 "Diffinity.exe",
                 LeftArguments,
                 RightArguments,
-                @"%ProgramFiles%\Diffinity\",
-                @"%UserProfile%\scoop\apps\diffinity\current\"),
+                @"%ProgramFiles%\Diffinity\"),
             notes: @"
  * Disable single instance:
    \ Preferences \ Tabs \ uncheck `Use single instance and open new diffs in tabs`.");

--- a/src/DiffEngine/Implementation/Kaleidoscope.cs
+++ b/src/DiffEngine/Implementation/Kaleidoscope.cs
@@ -23,6 +23,5 @@
             osx: new(
                 "ksdiff",
                 (temp, target) => $"\"{target}\" \"{temp}\"",
-                (temp, target) => $"\"{temp}\" \"{target}\"",
-                "/usr/local/bin/"));
+                (temp, target) => $"\"{temp}\" \"{target}\""));
 }

--- a/src/DiffEngine/Implementation/Meld.cs
+++ b/src/DiffEngine/Implementation/Meld.cs
@@ -30,8 +30,7 @@
             linux: new(
                 "meld",
                 LeftArguments,
-                RightArguments,
-                "/usr/bin/"),
+                RightArguments),
             osx: new(
                 "meld",
                 LeftArguments,

--- a/src/DiffEngine/Implementation/Neovim.cs
+++ b/src/DiffEngine/Implementation/Neovim.cs
@@ -24,9 +24,14 @@
             windows: new(
                 "nvim.exe",
                 LeftArguments,
-                RightArguments,
-                @"%ChocolateyToolsLocation%\neovim\*\"),
-            notes: @"
- * Assumes installed through Chocolatey https://chocolatey.org/packages/neovim/");
+                RightArguments),
+            linux: new(
+                "nvim",
+                LeftArguments,
+                RightArguments),
+            osx: new(
+                "nvim",
+                LeftArguments,
+                RightArguments));
     }
 }

--- a/src/DiffEngine/Implementation/P4MergeImage.cs
+++ b/src/DiffEngine/Implementation/P4MergeImage.cs
@@ -43,8 +43,7 @@
             linux: new(
                 "p4merge",
                 LeftArguments,
-                RightArguments,
-                "/usr/bin/"),
+                RightArguments),
             osx: new(
                 "p4merge",
                 LeftArguments,

--- a/src/DiffEngine/Implementation/P4MergeText.cs
+++ b/src/DiffEngine/Implementation/P4MergeText.cs
@@ -29,8 +29,7 @@
             linux: new(
                 "p4merge",
                 LeftArguments,
-                RightArguments,
-                "/usr/bin/"),
+                RightArguments),
             osx: new(
                 "p4merge",
                 LeftArguments,

--- a/src/DiffEngine/Implementation/Rider.cs
+++ b/src/DiffEngine/Implementation/Rider.cs
@@ -28,8 +28,7 @@
                 @"%LOCALAPPDATA%\JetBrains\Installations\Rider*\bin\",
                 @"%ProgramFiles%\JetBrains\JetBrains Rider *\bin\",
                 @"%JetBrains Rider%\",
-                @"%LOCALAPPDATA%\JetBrains\Toolbox\apps\Rider\*\*\bin\",
-                @"%UserProfile%\scoop\apps\rider\current\IDE\bin\"),
+                @"%LOCALAPPDATA%\JetBrains\Toolbox\apps\Rider\*\*\bin\"),
             osx: new(
                 "rider",
                 LeftArguments,

--- a/src/DiffEngine/Implementation/SublimeMerge.cs
+++ b/src/DiffEngine/Implementation/SublimeMerge.cs
@@ -29,8 +29,7 @@
             linux: new(
                 "smerge",
                 LeftArguments,
-                RightArguments,
-                "/usr/bin/"),
+                RightArguments),
             osx: new(
                 "smerge",
                 LeftArguments,

--- a/src/DiffEngine/Implementation/VsCode.cs
+++ b/src/DiffEngine/Implementation/VsCode.cs
@@ -26,8 +26,7 @@
                 LeftArguments,
                 RightArguments,
                 @"%LocalAppData%\Programs\Microsoft VS Code\",
-                @"%ProgramFiles%\Microsoft VS Code\",
-                @"%UserProfile%\scoop\apps\vscode\current\"),
+                @"%ProgramFiles%\Microsoft VS Code\"),
             linux: new(
                 "code",
                 LeftArguments,

--- a/src/DiffEngine/Implementation/VsCode.cs
+++ b/src/DiffEngine/Implementation/VsCode.cs
@@ -31,9 +31,7 @@
             linux: new(
                 "code",
                 LeftArguments,
-                RightArguments,
-                "/usr/local/bin/",
-                "/usr/bin/"),
+                RightArguments),
             osx: new(
                 "code",
                 LeftArguments,


### PR DESCRIPTION
No longer scans the following

 * `%UserProfile%\scoop\apps\beyondcompare\current\`
 * `%UserProfile%\scoop\apps\diffinity\current\`
 * `%ChocolateyToolsLocation%\neovim\*\`
 * `%UserProfile%\scoop\apps\rider\current\IDE\bin\`
 * `%UserProfile%\scoop\apps\vscode\current\`

Instead add the directory for the desired app to the `%PATH%` environment variable