### PR TITLE
Implement environment variable as a possible path source for diff tools

### DIFF
--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -109,7 +109,10 @@ ReSharper | Options | Tools | Unit Testing | Test Runner
 
 ## Supported Tools:
 
- <!-- include: diffTools. path: /src/DiffEngine.Tests/diffTools.include.md -->
+Tools location is automatically detected. If a tool is not found, it can be manually configured using an environment variable, that points to the executable.
+
+<!-- include: diffTools. path: /src/DiffEngine.Tests/diffTools.include.md -->
+
 ## Non-MDI tools
 
 Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track and close diffs.
@@ -131,7 +134,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `/solo /rightreadonly "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `/solo /leftreadonly "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_BeyondCompare`
+  * Default scanned paths:  
     * `%PATH%BCompare.exe`
     * `%ProgramFiles%\Beyond Compare *\BCompare.exe`
     * `%ProgramW6432%\Beyond Compare *\BCompare.exe`
@@ -141,7 +145,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-solo -rightreadonly "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-solo -leftreadonly "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_BeyondCompare`
+  * Default scanned paths:  
     * `%PATH%bcomp`
     * `/Applications/Beyond Compare.app/Contents/MacOS/bcomp`
 
@@ -149,7 +154,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-solo -rightreadonly "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-solo -leftreadonly "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_BeyondCompare`
+  * Default scanned paths:  
     * `%PATH%bcomp`
     * `/usr/lib/beyondcompare/bcomp`
 
@@ -169,7 +175,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-mi "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-mi "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_DeltaWalker`
+  * Default scanned paths:  
     * `%PATH%DeltaWalker.exe`
     * `C:\Program Files\Deltopia\DeltaWalker\DeltaWalker.exe`
 
@@ -177,7 +184,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-mi "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-mi "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_DeltaWalker`
+  * Default scanned paths:  
     * `%PATH%DeltaWalker`
     * `/Applications/DeltaWalker.app/Contents/MacOS/DeltaWalker`
 
@@ -197,7 +205,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Diffinity`
+  * Default scanned paths:  
     * `%PATH%Diffinity.exe`
     * `%ProgramFiles%\Diffinity\Diffinity.exe`
     * `%ProgramW6432%\Diffinity\Diffinity.exe`
@@ -218,7 +227,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--nosplash "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--nosplash "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_DiffMerge`
+  * Default scanned paths:  
     * `%PATH%sgdm.exe`
     * `%ProgramFiles%\SourceGear\Common\DiffMerge\sgdm.exe`
     * `%ProgramW6432%\SourceGear\Common\DiffMerge\sgdm.exe`
@@ -228,7 +238,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--nosplash "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--nosplash "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_DiffMerge`
+  * Default scanned paths:  
     * `%PATH%DiffMerge`
     * `/Applications/DiffMerge.app/Contents/MacOS/DiffMerge`
 
@@ -236,7 +247,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--nosplash "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--nosplash "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_DiffMerge`
+  * Default scanned paths:  
     * `%PATH%diffmerge`
 
 ### [ExamDiff](https://www.prestosoft.com/edp_examdiffpro.asp)
@@ -256,7 +268,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" /nh /diffonly /dn1:targetFile.txt /dn2:tempFile.txt `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" /nh /diffonly /dn1:tempFile.txt /dn2:targetFile.txt `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_ExamDiff`
+  * Default scanned paths:  
     * `%PATH%ExamDiff.exe`
     * `%ProgramFiles%\ExamDiff Pro\ExamDiff.exe`
     * `%ProgramW6432%\ExamDiff Pro\ExamDiff.exe`
@@ -281,7 +294,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" -ge2 `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" -ge1 `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Guiffy`
+  * Default scanned paths:  
     * `%PATH%guiffy.exe`
     * `%ProgramFiles%\Guiffy\guiffy.exe`
     * `%ProgramW6432%\Guiffy\guiffy.exe`
@@ -291,7 +305,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" -ge2 `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" -ge1 `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Guiffy`
+  * Default scanned paths:  
     * `%PATH%guiffyCL.command`
     * `/Applications/Guiffy/guiffyCL.command`
 
@@ -307,7 +322,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Kaleidoscope`
+  * Default scanned paths:  
     * `%PATH%ksdiff`
 
 ### [KDiff3](https://github.com/KDE/kdiff3)
@@ -325,7 +341,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" --cs CreateBakFiles=0 `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" --cs CreateBakFiles=0 `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_KDiff3`
+  * Default scanned paths:  
     * `%PATH%kdiff3.exe`
     * `%ProgramFiles%\KDiff3\kdiff3.exe`
     * `%ProgramW6432%\KDiff3\kdiff3.exe`
@@ -335,7 +352,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" --cs CreateBakFiles=0 `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" --cs CreateBakFiles=0 `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_KDiff3`
+  * Default scanned paths:  
     * `%PATH%kdiff3`
     * `/Applications/kdiff3.app/Contents/MacOS/kdiff3`
 
@@ -354,21 +372,24 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-d "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-d "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Neovim`
+  * Default scanned paths:  
     * `%PATH%nvim.exe`
 
 #### OSX settings:
 
   * Example target on left arguments: `-d "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-d "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Neovim`
+  * Default scanned paths:  
     * `%PATH%nvim`
 
 #### Linux settings:
 
   * Example target on left arguments: `-d "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-d "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Neovim`
+  * Default scanned paths:  
     * `%PATH%nvim`
 
 ### [P4Merge](https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge)
@@ -385,7 +406,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on right arguments for text: `"tempFile.txt" "targetFile.txt" `
   * Example target on left arguments for binary: `-C utf8-bom "tempFile.png" "targetFile.png" "targetFile.png" "targetFile.png" `
   * Example target on right arguments for binary: `-C utf8-bom "targetFile.png" "tempFile.png" "targetFile.png" "targetFile.png" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_P4Merge`
+  * Default scanned paths:  
     * `%PATH%p4merge.exe`
     * `%ProgramFiles%\Perforce\p4merge.exe`
     * `%ProgramW6432%\Perforce\p4merge.exe`
@@ -397,7 +419,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on right arguments for text: `"tempFile.txt" "targetFile.txt" `
   * Example target on left arguments for binary: `-C utf8-bom "tempFile.png" "targetFile.png" "targetFile.png" "targetFile.png" `
   * Example target on right arguments for binary: `-C utf8-bom "targetFile.png" "tempFile.png" "targetFile.png" "targetFile.png" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_P4Merge`
+  * Default scanned paths:  
     * `%PATH%p4merge`
     * `/Applications/p4merge.app/Contents/MacOS/p4merge`
 
@@ -407,7 +430,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on right arguments for text: `"tempFile.txt" "targetFile.txt" `
   * Example target on left arguments for binary: `-C utf8-bom "tempFile.png" "targetFile.png" "targetFile.png" "targetFile.png" `
   * Example target on right arguments for binary: `-C utf8-bom "targetFile.png" "tempFile.png" "targetFile.png" "targetFile.png" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_P4Merge`
+  * Default scanned paths:  
     * `%PATH%p4merge`
 
 ### [Rider](https://www.jetbrains.com/rider/)
@@ -425,7 +449,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Rider`
+  * Default scanned paths:  
     * `%PATH%rider64.exe`
     * `%LOCALAPPDATA%\JetBrains\Installations\Rider*\bin\rider64.exe`
     * `%ProgramFiles%\JetBrains\JetBrains Rider *\bin\rider64.exe`
@@ -438,7 +463,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Rider`
+  * Default scanned paths:  
     * `%PATH%rider`
     * `%HOME%/Library/Application Support/JetBrains/Toolbox/apps/Rider/*/*/Rider EAP.app/Contents/MacOS/rider`
     * `%HOME%/Library/Application Support/JetBrains/Toolbox/apps/Rider/*/*/Rider.app/Contents/MacOS/rider`
@@ -449,7 +475,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Rider`
+  * Default scanned paths:  
     * `%PATH%rider.sh`
     * `%HOME%/.local/share/JetBrains/Toolbox/apps/Rider/*/*/bin/rider.sh`
     * `/opt/jetbrains/rider/bin/rider.sh`
@@ -466,7 +493,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_TkDiff`
+  * Default scanned paths:  
     * `%PATH%tkdiff`
     * `/Applications/TkDiff.app/Contents/MacOS/tkdiff`
 
@@ -482,7 +510,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_TortoiseGitIDiff`
+  * Default scanned paths:  
     * `%PATH%TortoiseGitIDiff.exe`
     * `%ProgramFiles%\TortoiseGit\bin\TortoiseGitIDiff.exe`
     * `%ProgramW6432%\TortoiseGit\bin\TortoiseGitIDiff.exe`
@@ -499,7 +528,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_TortoiseGitMerge`
+  * Default scanned paths:  
     * `%PATH%TortoiseGitMerge.exe`
     * `%ProgramFiles%\TortoiseGit\bin\TortoiseGitMerge.exe`
     * `%ProgramW6432%\TortoiseGit\bin\TortoiseGitMerge.exe`
@@ -517,7 +547,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `/left:"targetFile.txt" /right:"tempFile.txt" `
   * Example target on right arguments: `/left:"tempFile.txt" /right:"targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_TortoiseIDiff`
+  * Default scanned paths:  
     * `%PATH%TortoiseIDiff.exe`
     * `%ProgramFiles%\TortoiseSVN\bin\TortoiseIDiff.exe`
     * `%ProgramW6432%\TortoiseSVN\bin\TortoiseIDiff.exe`
@@ -534,7 +565,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_TortoiseMerge`
+  * Default scanned paths:  
     * `%PATH%TortoiseMerge.exe`
     * `%ProgramFiles%\TortoiseSVN\bin\TortoiseMerge.exe`
     * `%ProgramW6432%\TortoiseSVN\bin\TortoiseMerge.exe`
@@ -559,7 +591,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-d "targetFile.txt" "tempFile.txt" -c "setl autoread | setl nobackup | set noswapfile" `
   * Example target on right arguments: `-d "tempFile.txt" "targetFile.txt" -c "setl autoread | setl nobackup | set noswapfile" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Vim`
+  * Default scanned paths:  
     * `%PATH%vim.exe`
     * `%ProgramFiles%\Vim\*\vim.exe`
     * `%ProgramW6432%\Vim\*\vim.exe`
@@ -569,7 +602,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-d "targetFile.txt" "tempFile.txt" -c "setl autoread | setl nobackup | set noswapfile" `
   * Example target on right arguments: `-d "tempFile.txt" "targetFile.txt" -c "setl autoread | setl nobackup | set noswapfile" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Vim`
+  * Default scanned paths:  
     * `%PATH%mvim`
     * `/Applications/MacVim.app/Contents/bin/mvim`
 
@@ -593,7 +627,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `/u /wr /e "targetFile.txt" "tempFile.txt" /dl "targetFile.txt" /dr "tempFile.txt" `
   * Example target on right arguments: `/u /wl /e "tempFile.txt" "targetFile.txt" /dl "tempFile.txt" /dr "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_WinMerge`
+  * Default scanned paths:  
     * `%PATH%WinMergeU.exe`
     * `%ProgramFiles%\WinMerge\WinMergeU.exe`
     * `%ProgramW6432%\WinMerge\WinMergeU.exe`
@@ -622,7 +657,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `/nowait "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `/nowait "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_AraxisMerge`
+  * Default scanned paths:  
     * `%PATH%Compare.exe`
     * `%ProgramFiles%\Araxis\Araxis Merge\Compare.exe`
     * `%ProgramW6432%\Araxis\Araxis Merge\Compare.exe`
@@ -632,7 +668,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-nowait "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-nowait "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_AraxisMerge`
+  * Default scanned paths:  
     * `%PATH%compare`
     * `/Applications/Araxis Merge.app/Contents/Utilities/compare`
 
@@ -651,7 +688,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_CodeCompare`
+  * Default scanned paths:  
     * `%PATH%CodeCompare.exe`
     * `%ProgramFiles%\Devart\Code Compare\CodeCompare.exe`
     * `%ProgramW6432%\Devart\Code Compare\CodeCompare.exe`
@@ -672,7 +710,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Meld`
+  * Default scanned paths:  
     * `%PATH%meld.exe`
     * `%LOCALAPPDATA%\Programs\Meld\meld.exe`
     * `%ProgramFiles%\Meld\meld.exe`
@@ -683,7 +722,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Meld`
+  * Default scanned paths:  
     * `%PATH%meld`
     * `/Applications/meld.app/Contents/MacOS/meld`
 
@@ -691,7 +731,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Meld`
+  * Default scanned paths:  
     * `%PATH%meld`
 
 ### [SublimeMerge](https://www.sublimemerge.com/)
@@ -709,7 +750,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `mergetool "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `mergetool "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_SublimeMerge`
+  * Default scanned paths:  
     * `%PATH%smerge.exe`
     * `%ProgramFiles%\Sublime Merge\smerge.exe`
     * `%ProgramW6432%\Sublime Merge\smerge.exe`
@@ -719,7 +761,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `mergetool "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `mergetool "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_SublimeMerge`
+  * Default scanned paths:  
     * `%PATH%smerge`
     * `/Applications/smerge.app/Contents/MacOS/smerge`
 
@@ -727,7 +770,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `mergetool "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `mergetool "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_SublimeMerge`
+  * Default scanned paths:  
     * `%PATH%smerge`
 
 ### [VisualStudio](https://docs.microsoft.com/en-us/visualstudio/ide/reference/diff)
@@ -741,7 +785,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `/diff "targetFile.txt" "tempFile.txt" "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `/diff "tempFile.txt" "targetFile.txt" "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_VisualStudio`
+  * Default scanned paths:  
     * `%PATH%devenv.exe`
     * `%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\IDE\devenv.exe`
     * `%ProgramW6432%\Microsoft Visual Studio\2022\Preview\Common7\IDE\devenv.exe`
@@ -771,7 +816,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_VisualStudioCode`
+  * Default scanned paths:  
     * `%PATH%code.exe`
     * `%LocalAppData%\Programs\Microsoft VS Code\code.exe`
     * `%ProgramFiles%\Microsoft VS Code\code.exe`
@@ -782,7 +828,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_VisualStudioCode`
+  * Default scanned paths:  
     * `%PATH%code`
     * `/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code`
 
@@ -790,5 +837,6 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
-    * `%PATH%code` <!-- endInclude -->
+  * Environment variable: `DiffEngine_VisualStudioCode`
+  * Default scanned paths:  
+    * `%PATH%code`

--- a/src/DiffEngine.Tests/DefinitionsTest.cs
+++ b/src/DiffEngine.Tests/DefinitionsTest.cs
@@ -1,4 +1,4 @@
-﻿public class DefinitionsTest :
+public class DefinitionsTest :
     XunitContextBase
 {
     [Fact]
@@ -12,6 +12,26 @@
         {
             AddToolLink(writer, tool);
         }
+    }
+
+    [Fact]
+    public void EnvironmentVariablesShouldBeUnique()
+    {
+        static void FindDuplicates(Func<OsSupport, OsSettings?> SelectOs)
+        {
+            var findDuplicates = Definitions.Tools
+                .Select(d => d.OsSupport)
+                .Select(SelectOs)
+                .Where(s => s is not null)
+                .GroupBy(x => x);
+            foreach (var group in findDuplicates)
+            {
+                Assert.Equal(1, group.Count());
+            }
+        }
+        FindDuplicates(os => os.Windows);
+        FindDuplicates(os => os.Osx);
+        FindDuplicates(os => os.Linux);
     }
 
     static void AddToolLink(TextWriter writer, Definition tool)
@@ -167,7 +187,7 @@
             writer.WriteLine($"""
                                * Example target on left arguments: `{leftText} `
                                * Example target on right arguments: `{rightText} `
-                             """ );
+                             """);
         }
         else
         {
@@ -176,7 +196,7 @@
                                * Example target on right arguments for text: `{rightText} `
                                * Example target on left arguments for binary: `{leftBinary} `
                                * Example target on right arguments for binary: `{rightBinary} `
-                             """ );
+                             """);
         }
     }
 

--- a/src/DiffEngine.Tests/OsSettingsResolverTest.cs
+++ b/src/DiffEngine.Tests/OsSettingsResolverTest.cs
@@ -1,17 +1,17 @@
-﻿public class OsSettingsResolverTest :
+public class OsSettingsResolverTest :
     XunitContextBase
 {
     [Fact]
     public void Simple()
     {
-        var paths = OsSettingsResolver.ExpandProgramFiles(new[] {"Path"}).ToList();
+        var paths = OsSettingsResolver.ExpandProgramFiles(new[] { "Path" }).ToList();
         Assert.Equal("Path", paths.Single());
     }
 
     [Fact]
     public void Expand()
     {
-        var paths = OsSettingsResolver.ExpandProgramFiles(new[] {@"%ProgramFiles%\Path"}).ToList();
+        var paths = OsSettingsResolver.ExpandProgramFiles(new[] { @"%ProgramFiles%\Path" }).ToList();
         Assert.Equal(@"%ProgramFiles%\Path", paths[0]);
         Assert.Equal(@"%ProgramW6432%\Path", paths[1]);
         Assert.Equal(@"%ProgramFiles(x86)%\Path", paths[2]);
@@ -33,6 +33,21 @@
             var found = OsSettingsResolver.TryFindInEnvPath("sh", out var filePath);
             Assert.Equal(true, found);
             Assert.NotNull(filePath);
+        }
+    }
+
+    [Fact]
+    public void EnvVar()
+    {
+        var launchArguments = new LaunchArguments(
+            Left: (temp, target) => string.Empty,
+            Right: (temp, target) => string.Empty);
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var found = OsSettingsResolver.Resolve(new OsSupport(Windows: new OsSettings("cmd.exe", launchArguments, "ComSpec", "")), out var filePath, out var launchArgs);
+            Assert.Equal(true, found);
+            Assert.Equal(@"C:\Windows\System32\cmd.exe", filePath, ignoreCase: true);
         }
     }
 

--- a/src/DiffEngine.Tests/OsSettingsResolverTest.cs
+++ b/src/DiffEngine.Tests/OsSettingsResolverTest.cs
@@ -45,7 +45,7 @@ public class OsSettingsResolverTest :
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            var found = OsSettingsResolver.Resolve(new OsSupport(Windows: new OsSettings("cmd.exe", launchArguments, "ComSpec", "")), out var filePath, out var launchArgs);
+            var found = OsSettingsResolver.Resolve(new OsSupport(Windows: new OsSettings("ComSpec", "cmd.exe", launchArguments, "")), out var filePath, out var launchArgs);
             Assert.Equal(true, found);
             Assert.Equal(@"C:\Windows\System32\cmd.exe", filePath, ignoreCase: true);
         }

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -20,7 +20,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `/solo /rightreadonly "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `/solo /leftreadonly "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_BeyondCompare`
+  * Default scanned paths:  
     * `%PATH%BCompare.exe`
     * `%ProgramFiles%\Beyond Compare *\BCompare.exe`
     * `%ProgramW6432%\Beyond Compare *\BCompare.exe`
@@ -30,7 +31,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-solo -rightreadonly "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-solo -leftreadonly "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_BeyondCompare`
+  * Default scanned paths:  
     * `%PATH%bcomp`
     * `/Applications/Beyond Compare.app/Contents/MacOS/bcomp`
 
@@ -38,7 +40,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-solo -rightreadonly "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-solo -leftreadonly "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_BeyondCompare`
+  * Default scanned paths:  
     * `%PATH%bcomp`
     * `/usr/lib/beyondcompare/bcomp`
 
@@ -58,7 +61,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-mi "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-mi "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_DeltaWalker`
+  * Default scanned paths:  
     * `%PATH%DeltaWalker.exe`
     * `C:\Program Files\Deltopia\DeltaWalker\DeltaWalker.exe`
 
@@ -66,7 +70,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-mi "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-mi "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_DeltaWalker`
+  * Default scanned paths:  
     * `%PATH%DeltaWalker`
     * `/Applications/DeltaWalker.app/Contents/MacOS/DeltaWalker`
 
@@ -86,7 +91,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Diffinity`
+  * Default scanned paths:  
     * `%PATH%Diffinity.exe`
     * `%ProgramFiles%\Diffinity\Diffinity.exe`
     * `%ProgramW6432%\Diffinity\Diffinity.exe`
@@ -107,7 +113,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--nosplash "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--nosplash "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_DiffMerge`
+  * Default scanned paths:  
     * `%PATH%sgdm.exe`
     * `%ProgramFiles%\SourceGear\Common\DiffMerge\sgdm.exe`
     * `%ProgramW6432%\SourceGear\Common\DiffMerge\sgdm.exe`
@@ -117,7 +124,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--nosplash "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--nosplash "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_DiffMerge`
+  * Default scanned paths:  
     * `%PATH%DiffMerge`
     * `/Applications/DiffMerge.app/Contents/MacOS/DiffMerge`
 
@@ -125,7 +133,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--nosplash "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--nosplash "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_DiffMerge`
+  * Default scanned paths:  
     * `%PATH%diffmerge`
 
 ### [ExamDiff](https://www.prestosoft.com/edp_examdiffpro.asp)
@@ -145,7 +154,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" /nh /diffonly /dn1:targetFile.txt /dn2:tempFile.txt `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" /nh /diffonly /dn1:tempFile.txt /dn2:targetFile.txt `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_ExamDiff`
+  * Default scanned paths:  
     * `%PATH%ExamDiff.exe`
     * `%ProgramFiles%\ExamDiff Pro\ExamDiff.exe`
     * `%ProgramW6432%\ExamDiff Pro\ExamDiff.exe`
@@ -170,7 +180,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" -ge2 `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" -ge1 `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Guiffy`
+  * Default scanned paths:  
     * `%PATH%guiffy.exe`
     * `%ProgramFiles%\Guiffy\guiffy.exe`
     * `%ProgramW6432%\Guiffy\guiffy.exe`
@@ -180,7 +191,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" -ge2 `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" -ge1 `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Guiffy`
+  * Default scanned paths:  
     * `%PATH%guiffyCL.command`
     * `/Applications/Guiffy/guiffyCL.command`
 
@@ -196,7 +208,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Kaleidoscope`
+  * Default scanned paths:  
     * `%PATH%ksdiff`
 
 ### [KDiff3](https://github.com/KDE/kdiff3)
@@ -214,7 +227,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" --cs CreateBakFiles=0 `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" --cs CreateBakFiles=0 `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_KDiff3`
+  * Default scanned paths:  
     * `%PATH%kdiff3.exe`
     * `%ProgramFiles%\KDiff3\kdiff3.exe`
     * `%ProgramW6432%\KDiff3\kdiff3.exe`
@@ -224,7 +238,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" --cs CreateBakFiles=0 `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" --cs CreateBakFiles=0 `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_KDiff3`
+  * Default scanned paths:  
     * `%PATH%kdiff3`
     * `/Applications/kdiff3.app/Contents/MacOS/kdiff3`
 
@@ -243,21 +258,24 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-d "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-d "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Neovim`
+  * Default scanned paths:  
     * `%PATH%nvim.exe`
 
 #### OSX settings:
 
   * Example target on left arguments: `-d "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-d "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Neovim`
+  * Default scanned paths:  
     * `%PATH%nvim`
 
 #### Linux settings:
 
   * Example target on left arguments: `-d "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-d "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Neovim`
+  * Default scanned paths:  
     * `%PATH%nvim`
 
 ### [P4Merge](https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge)
@@ -274,7 +292,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on right arguments for text: `"tempFile.txt" "targetFile.txt" `
   * Example target on left arguments for binary: `-C utf8-bom "tempFile.png" "targetFile.png" "targetFile.png" "targetFile.png" `
   * Example target on right arguments for binary: `-C utf8-bom "targetFile.png" "tempFile.png" "targetFile.png" "targetFile.png" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_P4Merge`
+  * Default scanned paths:  
     * `%PATH%p4merge.exe`
     * `%ProgramFiles%\Perforce\p4merge.exe`
     * `%ProgramW6432%\Perforce\p4merge.exe`
@@ -286,7 +305,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on right arguments for text: `"tempFile.txt" "targetFile.txt" `
   * Example target on left arguments for binary: `-C utf8-bom "tempFile.png" "targetFile.png" "targetFile.png" "targetFile.png" `
   * Example target on right arguments for binary: `-C utf8-bom "targetFile.png" "tempFile.png" "targetFile.png" "targetFile.png" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_P4Merge`
+  * Default scanned paths:  
     * `%PATH%p4merge`
     * `/Applications/p4merge.app/Contents/MacOS/p4merge`
 
@@ -296,7 +316,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on right arguments for text: `"tempFile.txt" "targetFile.txt" `
   * Example target on left arguments for binary: `-C utf8-bom "tempFile.png" "targetFile.png" "targetFile.png" "targetFile.png" `
   * Example target on right arguments for binary: `-C utf8-bom "targetFile.png" "tempFile.png" "targetFile.png" "targetFile.png" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_P4Merge`
+  * Default scanned paths:  
     * `%PATH%p4merge`
 
 ### [Rider](https://www.jetbrains.com/rider/)
@@ -314,7 +335,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Rider`
+  * Default scanned paths:  
     * `%PATH%rider64.exe`
     * `%LOCALAPPDATA%\JetBrains\Installations\Rider*\bin\rider64.exe`
     * `%ProgramFiles%\JetBrains\JetBrains Rider *\bin\rider64.exe`
@@ -327,7 +349,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Rider`
+  * Default scanned paths:  
     * `%PATH%rider`
     * `%HOME%/Library/Application Support/JetBrains/Toolbox/apps/Rider/*/*/Rider EAP.app/Contents/MacOS/rider`
     * `%HOME%/Library/Application Support/JetBrains/Toolbox/apps/Rider/*/*/Rider.app/Contents/MacOS/rider`
@@ -338,7 +361,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Rider`
+  * Default scanned paths:  
     * `%PATH%rider.sh`
     * `%HOME%/.local/share/JetBrains/Toolbox/apps/Rider/*/*/bin/rider.sh`
     * `/opt/jetbrains/rider/bin/rider.sh`
@@ -355,7 +379,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_TkDiff`
+  * Default scanned paths:  
     * `%PATH%tkdiff`
     * `/Applications/TkDiff.app/Contents/MacOS/tkdiff`
 
@@ -371,7 +396,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_TortoiseGitIDiff`
+  * Default scanned paths:  
     * `%PATH%TortoiseGitIDiff.exe`
     * `%ProgramFiles%\TortoiseGit\bin\TortoiseGitIDiff.exe`
     * `%ProgramW6432%\TortoiseGit\bin\TortoiseGitIDiff.exe`
@@ -388,7 +414,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_TortoiseGitMerge`
+  * Default scanned paths:  
     * `%PATH%TortoiseGitMerge.exe`
     * `%ProgramFiles%\TortoiseGit\bin\TortoiseGitMerge.exe`
     * `%ProgramW6432%\TortoiseGit\bin\TortoiseGitMerge.exe`
@@ -406,7 +433,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `/left:"targetFile.txt" /right:"tempFile.txt" `
   * Example target on right arguments: `/left:"tempFile.txt" /right:"targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_TortoiseIDiff`
+  * Default scanned paths:  
     * `%PATH%TortoiseIDiff.exe`
     * `%ProgramFiles%\TortoiseSVN\bin\TortoiseIDiff.exe`
     * `%ProgramW6432%\TortoiseSVN\bin\TortoiseIDiff.exe`
@@ -423,7 +451,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_TortoiseMerge`
+  * Default scanned paths:  
     * `%PATH%TortoiseMerge.exe`
     * `%ProgramFiles%\TortoiseSVN\bin\TortoiseMerge.exe`
     * `%ProgramW6432%\TortoiseSVN\bin\TortoiseMerge.exe`
@@ -448,7 +477,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-d "targetFile.txt" "tempFile.txt" -c "setl autoread | setl nobackup | set noswapfile" `
   * Example target on right arguments: `-d "tempFile.txt" "targetFile.txt" -c "setl autoread | setl nobackup | set noswapfile" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Vim`
+  * Default scanned paths:  
     * `%PATH%vim.exe`
     * `%ProgramFiles%\Vim\*\vim.exe`
     * `%ProgramW6432%\Vim\*\vim.exe`
@@ -458,7 +488,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-d "targetFile.txt" "tempFile.txt" -c "setl autoread | setl nobackup | set noswapfile" `
   * Example target on right arguments: `-d "tempFile.txt" "targetFile.txt" -c "setl autoread | setl nobackup | set noswapfile" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Vim`
+  * Default scanned paths:  
     * `%PATH%mvim`
     * `/Applications/MacVim.app/Contents/bin/mvim`
 
@@ -482,7 +513,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `/u /wr /e "targetFile.txt" "tempFile.txt" /dl "targetFile.txt" /dr "tempFile.txt" `
   * Example target on right arguments: `/u /wl /e "tempFile.txt" "targetFile.txt" /dl "tempFile.txt" /dr "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_WinMerge`
+  * Default scanned paths:  
     * `%PATH%WinMergeU.exe`
     * `%ProgramFiles%\WinMerge\WinMergeU.exe`
     * `%ProgramW6432%\WinMerge\WinMergeU.exe`
@@ -511,7 +543,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `/nowait "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `/nowait "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_AraxisMerge`
+  * Default scanned paths:  
     * `%PATH%Compare.exe`
     * `%ProgramFiles%\Araxis\Araxis Merge\Compare.exe`
     * `%ProgramW6432%\Araxis\Araxis Merge\Compare.exe`
@@ -521,7 +554,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `-nowait "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `-nowait "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_AraxisMerge`
+  * Default scanned paths:  
     * `%PATH%compare`
     * `/Applications/Araxis Merge.app/Contents/Utilities/compare`
 
@@ -540,7 +574,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_CodeCompare`
+  * Default scanned paths:  
     * `%PATH%CodeCompare.exe`
     * `%ProgramFiles%\Devart\Code Compare\CodeCompare.exe`
     * `%ProgramW6432%\Devart\Code Compare\CodeCompare.exe`
@@ -561,7 +596,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Meld`
+  * Default scanned paths:  
     * `%PATH%meld.exe`
     * `%LOCALAPPDATA%\Programs\Meld\meld.exe`
     * `%ProgramFiles%\Meld\meld.exe`
@@ -572,7 +608,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Meld`
+  * Default scanned paths:  
     * `%PATH%meld`
     * `/Applications/meld.app/Contents/MacOS/meld`
 
@@ -580,7 +617,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `"targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `"tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_Meld`
+  * Default scanned paths:  
     * `%PATH%meld`
 
 ### [SublimeMerge](https://www.sublimemerge.com/)
@@ -598,7 +636,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `mergetool "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `mergetool "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_SublimeMerge`
+  * Default scanned paths:  
     * `%PATH%smerge.exe`
     * `%ProgramFiles%\Sublime Merge\smerge.exe`
     * `%ProgramW6432%\Sublime Merge\smerge.exe`
@@ -608,7 +647,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `mergetool "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `mergetool "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_SublimeMerge`
+  * Default scanned paths:  
     * `%PATH%smerge`
     * `/Applications/smerge.app/Contents/MacOS/smerge`
 
@@ -616,7 +656,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `mergetool "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `mergetool "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_SublimeMerge`
+  * Default scanned paths:  
     * `%PATH%smerge`
 
 ### [VisualStudio](https://docs.microsoft.com/en-us/visualstudio/ide/reference/diff)
@@ -630,7 +671,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `/diff "targetFile.txt" "tempFile.txt" "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `/diff "tempFile.txt" "targetFile.txt" "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_VisualStudio`
+  * Default scanned paths:  
     * `%PATH%devenv.exe`
     * `%ProgramFiles%\Microsoft Visual Studio\2022\Preview\Common7\IDE\devenv.exe`
     * `%ProgramW6432%\Microsoft Visual Studio\2022\Preview\Common7\IDE\devenv.exe`
@@ -660,7 +702,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_VisualStudioCode`
+  * Default scanned paths:  
     * `%PATH%code.exe`
     * `%LocalAppData%\Programs\Microsoft VS Code\code.exe`
     * `%ProgramFiles%\Microsoft VS Code\code.exe`
@@ -671,7 +714,8 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_VisualStudioCode`
+  * Default scanned paths:  
     * `%PATH%code`
     * `/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code`
 
@@ -679,5 +723,6 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
 
   * Example target on left arguments: `--diff "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `--diff "tempFile.txt" "targetFile.txt" `
-  * Scanned paths:  
+  * Environment variable: `DiffEngine_VisualStudioCode`
+  * Default scanned paths:  
     * `%PATH%code`

--- a/src/DiffEngine/Implementation/AraxisMerge.cs
+++ b/src/DiffEngine/Implementation/AraxisMerge.cs
@@ -1,7 +1,9 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
-    public static Definition AraxisMerge() =>
-        new(
+    public static Definition AraxisMerge()
+    {
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.AraxisMerge)}";
+        return new(
             Tool: DiffTool.AraxisMerge,
             Url: "https://www.araxis.com/merge",
             AutoRefresh: true,
@@ -36,12 +38,14 @@
             },
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "Compare.exe",
                     new(
                         Left: (temp, target) => $"/nowait \"{target}\" \"{temp}\"",
                         Right: (temp, target) => $"/nowait \"{temp}\" \"{target}\""),
                     @"%ProgramFiles%\Araxis\Araxis Merge\"),
                 Osx: new(
+                    environmentVariable,
                     "compare",
                     new(
                         Left: (temp, target) => $"-nowait \"{target}\" \"{temp}\"",
@@ -53,5 +57,6 @@
                  * [MacOS command line usage](https://www.araxis.com/merge/documentation-os-x/command-line.en)
                  * [Installing MacOS command line](https://www.araxis.com/merge/documentation-os-x/installing.en)
                 """);
+    }
     //TODO: add doco about auto refresh
 }

--- a/src/DiffEngine/Implementation/BeyondCompare.cs
+++ b/src/DiffEngine/Implementation/BeyondCompare.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition BeyondCompare()
     {
@@ -22,6 +22,7 @@
             return $"-solo -leftreadonly \"{temp}\" \"{target}\"";
         }
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.BeyondCompare)}";
         return new(
             Tool: DiffTool.BeyondCompare,
             Url: "https://www.scootersoftware.com",
@@ -47,18 +48,21 @@
             },
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "BCompare.exe",
                     new(
                         LeftWindowsArguments,
                         RightWindowsArguments),
                     @"%ProgramFiles%\Beyond Compare *\"),
                 Linux: new(
+                    environmentVariable,
                     "bcomp",
                     new(
                         LeftOsxLinuxArguments,
                         RightOsxLinuxArguments),
                     "/usr/lib/beyondcompare/"),
                 Osx: new(
+                    environmentVariable,
                     "bcomp",
                     new(
                         LeftOsxLinuxArguments,

--- a/src/DiffEngine/Implementation/CodeCompare.cs
+++ b/src/DiffEngine/Implementation/CodeCompare.cs
@@ -1,7 +1,9 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
-    public static Definition CodeCompare() =>
-        new(
+    public static Definition CodeCompare()
+    {
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.CodeCompare)}";
+        return new(
             Tool: DiffTool.CodeCompare,
             Url: "https://www.devart.com/codecompare/",
             AutoRefresh: false,
@@ -12,10 +14,12 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "CodeCompare.exe",
                     new(
                         Left: (temp, target) => $"\"{target}\" \"{temp}\"",
                         Right: (temp, target) => $"\"{temp}\" \"{target}\""),
                     @"%ProgramFiles%\Devart\Code Compare\")),
             Notes: @" * [Command line reference](https://docs.devart.com/code-compare/using-command-line/comparing-via-command-line.html)");
+    }
 }

--- a/src/DiffEngine/Implementation/DeltaWalker.cs
+++ b/src/DiffEngine/Implementation/DeltaWalker.cs
@@ -1,10 +1,12 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition DeltaWalker()
     {
         var launchArguments = new LaunchArguments(
             Left: (temp, target) => $"-mi \"{target}\" \"{temp}\"",
             Right: (temp, target) => $"-mi \"{temp}\" \"{target}\"");
+
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.DeltaWalker)}";
 
         return new(
             Tool: DiffTool.DeltaWalker,
@@ -52,10 +54,12 @@
             },
             OsSupport: new(
                 Osx: new(
+                    environmentVariable,
                     "DeltaWalker",
                     launchArguments,
                     "/Applications/DeltaWalker.app/Contents/MacOS/"),
                 Windows: new(
+                    environmentVariable,
                     "DeltaWalker.exe",
                     launchArguments,
                     @"C:\Program Files\Deltopia\DeltaWalker\")),

--- a/src/DiffEngine/Implementation/DiffMerge.cs
+++ b/src/DiffEngine/Implementation/DiffMerge.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition DiffMerge()
     {
@@ -6,6 +6,7 @@
             Left: (temp, target) => $"--nosplash \"{target}\" \"{temp}\"",
             Right: (temp, target) => $"--nosplash \"{temp}\" \"{target}\"");
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.DiffMerge)}";
         return new(
             Tool: DiffTool.DiffMerge,
             Url: "https://www.sourcegear.com/diffmerge/",

--- a/src/DiffEngine/Implementation/Diffinity.cs
+++ b/src/DiffEngine/Implementation/Diffinity.cs
@@ -1,7 +1,9 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
-    public static Definition Diffinity() =>
-        new(
+    public static Definition Diffinity()
+    {
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.Diffinity)}";
+        return new(
             Tool: DiffTool.Diffinity,
             Url: "https://truehumandesign.se/s_diffinity.php",
             AutoRefresh: true,
@@ -12,6 +14,7 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "Diffinity.exe",
                     new(
                         Left: (temp, target) => $"\"{target}\" \"{temp}\"",
@@ -21,4 +24,5 @@
                  * Disable single instance:
                    \ Preferences \ Tabs \ uncheck `Use single instance and open new diffs in tabs`.
                 """);
+    }
 }

--- a/src/DiffEngine/Implementation/ExamDiff.cs
+++ b/src/DiffEngine/Implementation/ExamDiff.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition ExamDiff()
     {
@@ -16,6 +16,7 @@
             return $"\"{temp}\" \"{target}\" /nh /diffonly /dn1:{tempTitle} /dn2:{targetTitle}";
         }
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.ExamDiff)}";
         return new(
             Tool: DiffTool.ExamDiff,
             Url: "https://www.prestosoft.com/edp_examdiffpro.asp",
@@ -27,6 +28,7 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "ExamDiff.exe",
                     new(LeftArguments, RightArguments),
                     @"%ProgramFiles%\ExamDiff Pro\")),

--- a/src/DiffEngine/Implementation/Guiffy.cs
+++ b/src/DiffEngine/Implementation/Guiffy.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition Guiffy()
     {
@@ -6,6 +6,7 @@
             Left: (temp, target) => $"\"{target}\" \"{temp}\" -ge2",
             Right: (temp, target) => $"\"{temp}\" \"{target}\" -ge1");
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.Guiffy)}";
         return new(
             Tool: DiffTool.Guiffy,
             Url: "https://www.guiffy.com/",

--- a/src/DiffEngine/Implementation/ImplementationDefaults.cs
+++ b/src/DiffEngine/Implementation/ImplementationDefaults.cs
@@ -1,0 +1,4 @@
+static partial class Implementation
+{
+    const string DefaultEnvironmentVariablePrefix = "DiffEngine";
+}

--- a/src/DiffEngine/Implementation/KDiff3.cs
+++ b/src/DiffEngine/Implementation/KDiff3.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition KDiff3()
     {
@@ -6,6 +6,7 @@
             Left: (temp, target) => $"\"{target}\" \"{temp}\" --cs CreateBakFiles=0",
             Right: (temp, target) => $"\"{temp}\" \"{target}\" --cs CreateBakFiles=0");
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.KDiff3)}";
         return new(
             Tool: DiffTool.KDiff3,
             Url: "https://github.com/KDE/kdiff3",
@@ -17,10 +18,12 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "kdiff3.exe",
                     launchArguments,
                     @"%ProgramFiles%\KDiff3\"),
                 Osx: new(
+                    environmentVariable,
                     "kdiff3",
                     launchArguments,
                     "/Applications/kdiff3.app/Contents/MacOS/")),

--- a/src/DiffEngine/Implementation/Kaleidoscope.cs
+++ b/src/DiffEngine/Implementation/Kaleidoscope.cs
@@ -1,7 +1,9 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
-    public static Definition Kaleidoscope() =>
-        new(
+    public static Definition Kaleidoscope()
+    {
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.Kaleidoscope)}";
+        return new(
             Tool: DiffTool.Kaleidoscope,
             Url: "https://www.kaleidoscopeapp.com/",
             AutoRefresh: true,
@@ -22,8 +24,10 @@
             },
             OsSupport: new(
                 Osx: new(
+                    environmentVariable,
                     "ksdiff",
                     new(
                         Left: (temp, target) => $"\"{target}\" \"{temp}\"",
                         Right: (temp, target) => $"\"{temp}\" \"{target}\""))));
+    }
 }

--- a/src/DiffEngine/Implementation/Meld.cs
+++ b/src/DiffEngine/Implementation/Meld.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition Meld()
     {
@@ -6,6 +6,7 @@
             Left: (temp, target) => $"\"{target}\" \"{temp}\"",
             Right: (temp, target) => $"\"{temp}\" \"{target}\"");
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.Meld)}";
         return new(
             Tool: DiffTool.Meld,
             Url: "https://meldmerge.org/",
@@ -17,14 +18,17 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "meld.exe",
                     launchArguments,
                     @"%LOCALAPPDATA%\Programs\Meld\",
                     @"%ProgramFiles%\Meld\"),
                 Linux: new(
+                    environmentVariable,
                     "meld",
                     launchArguments),
                 Osx: new(
+                    environmentVariable,
                     "meld",
                     launchArguments,
                     "/Applications/meld.app/Contents/MacOS/")),

--- a/src/DiffEngine/Implementation/Neovim.cs
+++ b/src/DiffEngine/Implementation/Neovim.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition Neovim()
     {
@@ -6,6 +6,7 @@
             Left: (temp, target) => $"-d \"{target}\" \"{temp}\"",
             Right: (temp, target) => $"-d \"{temp}\" \"{target}\"");
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.Neovim)}";
         return new(
             Tool: DiffTool.Neovim,
             Url: "https://neovim.io/",
@@ -16,9 +17,18 @@
             Cost: "Free with option to sponsor",
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
-                Windows: new("nvim.exe", launchArguments),
-                Linux: new("nvim", launchArguments),
-                Osx: new("nvim", launchArguments)),
-            Notes:" * https://neovim.io/doc/user/diff.html");
+                Windows: new(
+                    environmentVariable,
+                    "nvim.exe",
+                    launchArguments),
+                Linux: new(
+                    environmentVariable,
+                    "nvim",
+                    launchArguments),
+                Osx: new(
+                    environmentVariable,
+                    "nvim",
+                    launchArguments)),
+            Notes: " * https://neovim.io/doc/user/diff.html");
     }
 }

--- a/src/DiffEngine/Implementation/P4Merge.cs
+++ b/src/DiffEngine/Implementation/P4Merge.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition P4Merge()
     {
@@ -22,6 +22,7 @@
                 return $"-C utf8-bom \"{target}\" \"{temp}\" \"{target}\" \"{target}\"";
             });
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.P4Merge)}";
         return new(
             Tool: DiffTool.P4Merge,
             Url: "https://www.perforce.com/products/helix-core-apps/merge-diff-tool-p4merge",
@@ -47,13 +48,16 @@
             },
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "p4merge.exe",
                     launchArguments,
                     @"%ProgramFiles%\Perforce\"),
                 Linux: new(
+                    environmentVariable,
                     "p4merge",
                     launchArguments),
                 Osx: new(
+                    environmentVariable,
                     "p4merge",
                     launchArguments,
                     "/Applications/p4merge.app/Contents/MacOS/")));

--- a/src/DiffEngine/Implementation/Rider.cs
+++ b/src/DiffEngine/Implementation/Rider.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition Rider()
     {
@@ -6,6 +6,7 @@
             Left: (temp, target) => $"diff \"{target}\" \"{temp}\"",
             Right: (temp, target) => $"diff \"{temp}\" \"{target}\"");
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.Rider)}";
         return new(
             Tool: DiffTool.Rider,
             Url: "https://www.jetbrains.com/rider/",
@@ -17,6 +18,7 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "rider64.exe",
                     launchArguments,
                     @"%LOCALAPPDATA%\JetBrains\Installations\Rider*\bin\",
@@ -24,6 +26,7 @@
                     @"%JetBrains Rider%\",
                     @"%LOCALAPPDATA%\JetBrains\Toolbox\apps\Rider\*\*\bin\"),
                 Osx: new(
+                    environmentVariable,
                     "rider",
                     launchArguments,
                     "%HOME%/Library/Application Support/JetBrains/Toolbox/apps/Rider/*/*/Rider EAP.app/Contents/MacOS/",
@@ -31,6 +34,7 @@
                     "/Applications/Rider EAP.app/Contents/MacOS/",
                     "/Applications/Rider.app/Contents/MacOS/"),
                 Linux: new(
+                    environmentVariable,
                     "rider.sh",
                     launchArguments,
                     "%HOME%/.local/share/JetBrains/Toolbox/apps/Rider/*/*/bin/",

--- a/src/DiffEngine/Implementation/SublimeMerge.cs
+++ b/src/DiffEngine/Implementation/SublimeMerge.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition SublimeMerge()
     {
@@ -6,6 +6,7 @@
             Left: (temp, target) => $"mergetool \"{target}\" \"{temp}\"",
             Right: (temp, target) => $"mergetool \"{temp}\" \"{target}\"");
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.SublimeMerge)}";
         return new(
             Tool: DiffTool.SublimeMerge,
             Url: "https://www.sublimemerge.com/",
@@ -17,13 +18,16 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "smerge.exe",
                     launchArguments,
                     @"%ProgramFiles%\Sublime Merge\"),
                 Linux: new(
+                    environmentVariable,
                     "smerge",
                     launchArguments),
                 Osx: new(
+                    environmentVariable,
                     "smerge",
                     launchArguments,
                     "/Applications/smerge.app/Contents/MacOS/")),

--- a/src/DiffEngine/Implementation/TkDiff.cs
+++ b/src/DiffEngine/Implementation/TkDiff.cs
@@ -1,7 +1,9 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
-    public static Definition TkDiff() =>
-        new(
+    public static Definition TkDiff()
+    {
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.TkDiff)}";
+        return new(
             Tool: DiffTool.TkDiff,
             Url: "https://sourceforge.net/projects/tkdiff/",
             AutoRefresh: false,
@@ -12,9 +14,11 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Osx: new(
+                    environmentVariable,
                     "tkdiff",
                     new(
                         Left: (temp, target) => $"\"{target}\" \"{temp}\"",
                         Right: (temp, target) => $"\"{temp}\" \"{target}\""),
                     "/Applications/TkDiff.app/Contents/MacOS/")));
+    }
 }

--- a/src/DiffEngine/Implementation/TortoiseGitIDiff.cs
+++ b/src/DiffEngine/Implementation/TortoiseGitIDiff.cs
@@ -1,7 +1,9 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
-    public static Definition TortoiseGitIDiff() =>
-        new(
+    public static Definition TortoiseGitIDiff()
+    {
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.TortoiseGitIDiff)}";
+        return new(
             Tool: DiffTool.TortoiseGitIDiff,
             Url: "https://tortoisegit.org/docs/tortoisegitmerge/",
             AutoRefresh: false,
@@ -22,9 +24,11 @@
             },
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "TortoiseGitIDiff.exe",
                     new(
                         Left: (temp, target) => $"\"{target}\" \"{temp}\"",
                         Right: (temp, target) => $"\"{temp}\" \"{target}\""),
                     @"%ProgramFiles%\TortoiseGit\bin\")));
+    }
 }

--- a/src/DiffEngine/Implementation/TortoiseGitMerge.cs
+++ b/src/DiffEngine/Implementation/TortoiseGitMerge.cs
@@ -1,7 +1,9 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
-    public static Definition TortoiseGitMerge() =>
-        new(
+    public static Definition TortoiseGitMerge()
+    {
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.TortoiseGitMerge)}";
+        return new(
             Tool: DiffTool.TortoiseGitMerge,
             Url: "https://tortoisegit.org/docs/tortoisegitmerge/",
             AutoRefresh: false,
@@ -12,9 +14,11 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "TortoiseGitMerge.exe",
                     new(
                         Left: (temp, target) => $"\"{target}\" \"{temp}\"",
                         Right: (temp, target) => $"\"{temp}\" \"{target}\""),
                     @"%ProgramFiles%\TortoiseGit\bin\")));
+    }
 }

--- a/src/DiffEngine/Implementation/TortoiseIDiff.cs
+++ b/src/DiffEngine/Implementation/TortoiseIDiff.cs
@@ -1,7 +1,9 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
-    public static Definition TortoiseIDiff() =>
-        new(
+    public static Definition TortoiseIDiff()
+    {
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.TortoiseIDiff)}";
+        return new(
             Tool: DiffTool.TortoiseIDiff,
             Url: "https://tortoisesvn.net/TortoiseIDiff.html",
             AutoRefresh: false,
@@ -22,9 +24,11 @@
             },
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "TortoiseIDiff.exe",
                     new(
                         Left: (temp, target) => $"/left:\"{target}\" /right:\"{temp}\"",
                         Right: (temp, target) => $"/left:\"{temp}\" /right:\"{target}\""),
                     @"%ProgramFiles%\TortoiseSVN\bin\")));
+    }
 }

--- a/src/DiffEngine/Implementation/TortoiseMerge.cs
+++ b/src/DiffEngine/Implementation/TortoiseMerge.cs
@@ -1,7 +1,9 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
-    public static Definition TortoiseMerge() =>
-        new(
+    public static Definition TortoiseMerge()
+    {
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.TortoiseMerge)}";
+        return new(
             Tool: DiffTool.TortoiseMerge,
             Url: "https://tortoisesvn.net/TortoiseMerge.html",
             AutoRefresh: false,
@@ -12,9 +14,11 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "TortoiseMerge.exe",
                     new(
                         Left: (temp, target) => $"\"{target}\" \"{temp}\"",
                         Right: (temp, target) => $"\"{temp}\" \"{target}\""),
                     @"%ProgramFiles%\TortoiseSVN\bin\")));
+    }
 }

--- a/src/DiffEngine/Implementation/Vim.cs
+++ b/src/DiffEngine/Implementation/Vim.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition Vim()
     {
@@ -6,6 +6,7 @@
             Left: (temp, target) => $"-d \"{target}\" \"{temp}\" -c \"setl autoread | setl nobackup | set noswapfile\"",
             Right: (temp, target) => $"-d \"{temp}\" \"{target}\" -c \"setl autoread | setl nobackup | set noswapfile\"");
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.Vim)}";
         return new(
             Tool: DiffTool.Vim,
             Url: "https://www.vim.org/",
@@ -17,10 +18,12 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "vim.exe",
                     launchArguments,
                     @"%ProgramFiles%\Vim\*\"),
                 Osx: new(
+                    environmentVariable,
                     "mvim",
                     launchArguments,
                     "/Applications/MacVim.app/Contents/bin/")),

--- a/src/DiffEngine/Implementation/VisualStudio.cs
+++ b/src/DiffEngine/Implementation/VisualStudio.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition VisualStudio()
     {
@@ -16,6 +16,7 @@
             return $"/diff \"{temp}\" \"{target}\" \"{tempTitle}\" \"{targetTitle}\"";
         }
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.VisualStudio)}";
         return new(
             Tool: DiffTool.VisualStudio,
             Url: "https://docs.microsoft.com/en-us/visualstudio/ide/reference/diff",
@@ -27,6 +28,7 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "devenv.exe", new(
                         LeftArguments,
                         RightArguments),

--- a/src/DiffEngine/Implementation/VsCode.cs
+++ b/src/DiffEngine/Implementation/VsCode.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition VisualStudioCode()
     {
@@ -17,6 +17,7 @@
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
+                    $"DiffEngine_{DiffTool.VisualStudioCode.ToString()}",
                     "code.exe",
                     launchArguments,
                     @"%LocalAppData%\Programs\Microsoft VS Code\",

--- a/src/DiffEngine/Implementation/VsCode.cs
+++ b/src/DiffEngine/Implementation/VsCode.cs
@@ -5,7 +5,7 @@ static partial class Implementation
         var launchArguments = new LaunchArguments(
             Left: (temp, target) => $"--diff \"{target}\" \"{temp}\"",
             Right: (temp, target) => $"--diff \"{temp}\" \"{target}\"");
-
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.VisualStudioCode)}";
         return new(
             Tool: DiffTool.VisualStudioCode,
             Url: "https://code.visualstudio.com",
@@ -17,15 +17,17 @@ static partial class Implementation
             BinaryExtensions: Array.Empty<string>(),
             OsSupport: new(
                 Windows: new(
-                    $"DiffEngine_{DiffTool.VisualStudioCode.ToString()}",
+                    environmentVariable,
                     "code.exe",
                     launchArguments,
                     @"%LocalAppData%\Programs\Microsoft VS Code\",
                     @"%ProgramFiles%\Microsoft VS Code\"),
                 Linux: new(
+                    environmentVariable,
                     "code",
                     launchArguments),
                 Osx: new(
+                    environmentVariable,
                     "code",
                     launchArguments,
                     "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/")),

--- a/src/DiffEngine/Implementation/WinMerge.cs
+++ b/src/DiffEngine/Implementation/WinMerge.cs
@@ -1,4 +1,4 @@
-﻿static partial class Implementation
+static partial class Implementation
 {
     public static Definition WinMerge()
     {
@@ -16,6 +16,7 @@
             return $"/u /wl /e \"{temp}\" \"{target}\" /dl \"{tempTitle}\" /dr \"{targetTitle}\"";
         }
 
+        var environmentVariable = $"${DefaultEnvironmentVariablePrefix}_{nameof(DiffTool.WinMerge)}";
         return new(
             Tool: DiffTool.WinMerge,
             Url: "https://winmerge.org/",
@@ -78,6 +79,7 @@
             },
             OsSupport: new(
                 Windows: new(
+                    environmentVariable,
                     "WinMergeU.exe",
                     new(
                         LeftArguments,

--- a/src/DiffEngine/OsSettings.cs
+++ b/src/DiffEngine/OsSettings.cs
@@ -1,14 +1,24 @@
-﻿namespace DiffEngine;
+namespace DiffEngine;
 
-public record OsSettings(string ExeName, LaunchArguments LaunchArguments, params string[] SearchDirectories)
+public record OsSettings(string? EnvironmentVariable, string ExeName, LaunchArguments LaunchArguments, params string[] SearchDirectories)
 {
+    public OsSettings(string ExeName, LaunchArguments LaunchArguments, params string[] SearchDirectories) :
+        this(null, ExeName, LaunchArguments, SearchDirectories)
+    {
+    }
+
+    public OsSettings(string? environmentVariable, string exeName, LaunchArguments launchArguments, string searchDirectory) :
+        this(environmentVariable, exeName, launchArguments, new[] { searchDirectory })
+    {
+    }
+
     public OsSettings(string exeName, LaunchArguments launchArguments, string searchDirectory) :
-        this(exeName, launchArguments, new[] {searchDirectory})
+        this(null, exeName, launchArguments, new[] { searchDirectory })
     {
     }
 
     public OsSettings(string exeName, LaunchArguments launchArguments) :
-        this(exeName, launchArguments, Array.Empty<string>())
+        this(null, exeName, launchArguments, Array.Empty<string>())
     {
     }
 }

--- a/src/DiffEngine/OsSettingsResolver.cs
+++ b/src/DiffEngine/OsSettingsResolver.cs
@@ -1,4 +1,4 @@
-﻿static class OsSettingsResolver
+static class OsSettingsResolver
 {
     static string[] envPaths;
 
@@ -55,6 +55,31 @@
         if (os != null &&
             RuntimeInformation.IsOSPlatform(platform))
         {
+            if (os.EnvironmentVariable is not null)
+            {
+                var basePath = Environment.GetEnvironmentVariable(os.EnvironmentVariable);
+                if (basePath is not null)
+                {
+                    if (basePath.EndsWith(os.ExeName) && File.Exists(basePath))
+                    {
+                    }
+                    else if (Directory.Exists(basePath))
+                    {
+                        basePath = Path.Combine(basePath, os.ExeName);
+                    }
+                    else
+                    {
+                        launchArguments = null;
+                        path = null;
+                        return false;
+                    }
+                    if (WildcardFileFinder.TryFind(basePath, out path))
+                    {
+                        launchArguments = os.LaunchArguments;
+                        return true;
+                    }
+                }
+            }
             if (TryFindExe(os.ExeName, os.SearchDirectories, out path))
             {
                 launchArguments = os.LaunchArguments;


### PR DESCRIPTION
Closes #310 

Given that I don't know which versions and tools are "portable", that is, installable basically anywhere, I've just set up Visual Studio Code environment variable: `DiffEngine_VisualStudioCode` for windows.

If you want more variables already set in this PR just tell me for which OS and diff tools -> var name.