### PR TITLE
remove `%JetBrains Rider%\rider64.exe` from scanned locations

### DIFF
--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -444,7 +444,6 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
     * `%ProgramFiles%\JetBrains\JetBrains Rider *\bin\rider64.exe`
     * `%ProgramW6432%\JetBrains\JetBrains Rider *\bin\rider64.exe`
     * `%ProgramFiles(x86)%\JetBrains\JetBrains Rider *\bin\rider64.exe`
-    * `%JetBrains Rider%\rider64.exe`
     * `%LOCALAPPDATA%\JetBrains\Toolbox\apps\Rider\*\*\bin\rider64.exe`
 
 #### OSX settings:

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -331,7 +331,6 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
     * `%ProgramFiles%\JetBrains\JetBrains Rider *\bin\rider64.exe`
     * `%ProgramW6432%\JetBrains\JetBrains Rider *\bin\rider64.exe`
     * `%ProgramFiles(x86)%\JetBrains\JetBrains Rider *\bin\rider64.exe`
-    * `%JetBrains Rider%\rider64.exe`
     * `%LOCALAPPDATA%\JetBrains\Toolbox\apps\Rider\*\*\bin\rider64.exe`
 
 #### OSX settings:

--- a/src/DiffEngine/Implementation/Rider.cs
+++ b/src/DiffEngine/Implementation/Rider.cs
@@ -21,7 +21,6 @@ static partial class Implementation
                     launchArguments,
                     @"%LOCALAPPDATA%\JetBrains\Installations\Rider*\bin\",
                     @"%ProgramFiles%\JetBrains\JetBrains Rider *\bin\",
-                    @"%JetBrains Rider%\",
                     @"%LOCALAPPDATA%\JetBrains\Toolbox\apps\Rider\*\*\bin\"),
                 Osx: new(
                     "rider",


### PR DESCRIPTION
since this was a legacy location from an early version of the JetBrains toolbox