### PR TITLE
Make project compatible with .NET Standard 2.0

### DIFF
--- a/src/DiffEngine/DiffEngine.csproj
+++ b/src/DiffEngine/DiffEngine.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net472;net48</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="DiffEngine" />


### PR DESCRIPTION
This change makes the project compatible with .NET Standard 2.0, which Shouldy and ApprovalTests targets.  This change also reduces the size of the nuget download.  Note: The only reason .NET 6.0 target exists at all is because I can't figure out how to get PolySharp to exclude generating the ModuleInitializerAttribute.