### PR TITLE
Add path for Rider via Mac Toolbox

### DIFF
--- a/src/DiffEngine/Implementation/Rider.cs
+++ b/src/DiffEngine/Implementation/Rider.cs
@@ -25,7 +25,8 @@ static partial class Implementation
                 Osx: new(
                     "rider",
                     launchArguments,
-                    "/Applications/Rider.app/Contents/MacOS/"),
+                    "/Applications/Rider.app/Contents/MacOS/",
+                    "/usr/local/bin/"),
                 Linux: new(
                     "rider.sh",
                     launchArguments,


### PR DESCRIPTION
I believe this is the change I need as a Toolbox user on Mac may be this simple.

According to 
https://www.jetbrains.com/help/rider/Working_with_the_IDE_Features_from_Command_Line.html#toolbox
the Linux path is now out of date. I think this is a change JetBrains made in version 2 of Toolbox. I expect `~/.local/share/JetBrains/Toolbox/scripts`.

Then there's the Windows path, which is `%LOCALAPPDATA%\JetBrains\Toolbox\scripts`