### PR TITLE
Support current user installs of Beyond Compare

### DIFF
--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -158,6 +158,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `/solo /rightreadonly /nobackups "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `/solo /leftreadonly /nobackups "tempFile.txt" "targetFile.txt" `
   * Scanned paths:
+    * `%LOCALAPPDATA%\Programs\Beyond Compare *\BCompare.exe`
     * `%ProgramFiles%\Beyond Compare *\BCompare.exe`
     * `%ProgramW6432%\Beyond Compare *\BCompare.exe`
     * `%ProgramFiles(x86)%\Beyond Compare *\BCompare.exe`

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -23,6 +23,7 @@ Non-MDI tools are preferred since it allows [DiffEngineTray](tray.md) to track a
   * Example target on left arguments: `/solo /rightreadonly /nobackups "targetFile.txt" "tempFile.txt" `
   * Example target on right arguments: `/solo /leftreadonly /nobackups "tempFile.txt" "targetFile.txt" `
   * Scanned paths:
+    * `%LOCALAPPDATA%\Programs\Beyond Compare *\BCompare.exe`
     * `%ProgramFiles%\Beyond Compare *\BCompare.exe`
     * `%ProgramW6432%\Beyond Compare *\BCompare.exe`
     * `%ProgramFiles(x86)%\Beyond Compare *\BCompare.exe`

--- a/src/DiffEngine/Implementation/BeyondCompare.cs
+++ b/src/DiffEngine/Implementation/BeyondCompare.cs
@@ -44,6 +44,7 @@ static partial class Implementation
                     new(
                         LeftWindowsArguments,
                         RightWindowsArguments),
+                    @"%LOCALAPPDATA%\Programs\Beyond Compare *\",
                     @"%ProgramFiles%\Beyond Compare *\"),
                 Linux: new(
                     "bcompare",


### PR DESCRIPTION
I recently reinstalled Windows and couldn't figure out why Beyond Compare wasn't opening anymore. It looks to be due to installing it for the current user only which puts it in `C:\Users\brian\AppData\Local\Programs\Beyond Compare 5`.

Meld checks this location so I copied how that was set up https://github.com/VerifyTests/DiffEngine/blob/05b35769a3442b4cb0f7558768e3ca6ab13a525c/src/DiffEngine/Implementation/Meld.cs#L22