### PR TITLE
Fix launch canKill inversion and tray bugs

### DIFF
--- a/src/DiffEngine/DiffRunner.cs
+++ b/src/DiffEngine/DiffRunner.cs
@@ -156,11 +156,12 @@ public static partial class DiffRunner
 
         tool.CommandAndArguments(tempFile, targetFile, out var arguments, out var command);
 
+        var canKill = !tool.IsMdi;
         if (ProcessCleanup.TryGetProcessInfo(command, out var processCommand))
         {
             if (tool.AutoRefresh)
             {
-                DiffEngineTray.AddMove(tempFile, targetFile, tool.ExePath, arguments, tool.IsMdi, processCommand.Process);
+                DiffEngineTray.AddMove(tempFile, targetFile, tool.ExePath, arguments, canKill, processCommand.Process);
                 return LaunchResult.AlreadyRunningAndSupportsRefresh;
             }
 
@@ -169,13 +170,13 @@ public static partial class DiffRunner
 
         if (MaxInstance.Reached())
         {
-            DiffEngineTray.AddMove(tempFile, targetFile, tool.ExePath, arguments, tool.IsMdi, null);
+            DiffEngineTray.AddMove(tempFile, targetFile, tool.ExePath, arguments, canKill, null);
             return LaunchResult.TooManyRunningDiffTools;
         }
 
         var processId = LaunchProcess(tool, arguments);
 
-        DiffEngineTray.AddMove(tempFile, targetFile, tool.ExePath, arguments, !tool.IsMdi, processId);
+        DiffEngineTray.AddMove(tempFile, targetFile, tool.ExePath, arguments, canKill, processId);
 
         return LaunchResult.StartedNewInstance;
     }

--- a/src/DiffEngine/Tray/DiffEngineTray.cs
+++ b/src/DiffEngine/Tray/DiffEngineTray.cs
@@ -19,7 +19,7 @@ public static class DiffEngineTray
         }
     }
 
-    public static bool IsRunning { get; }
+    public static bool IsRunning { get; internal set; }
 
     public static void AddDelete(string file)
     {

--- a/src/DiffEngine/Tray/PiperClient.cs
+++ b/src/DiffEngine/Tray/PiperClient.cs
@@ -10,7 +10,7 @@
         Cancel cancel = default)
     {
         var payload = BuildDeletePayload(file);
-        return SendAsync(payload);
+        return SendAsync(payload, cancel);
     }
 
     static string BuildDeletePayload(string file) =>
@@ -41,7 +41,7 @@
         Cancel cancel = default)
     {
         var payload = BuildMovePayload(tempFile, targetFile, exe, arguments, canKill, processId);
-        return SendAsync(payload);
+        return SendAsync(payload, cancel);
     }
 
     public static string BuildMovePayload(string tempFile, string targetFile, string? exe, string? arguments, bool canKill, int? processId)
@@ -91,13 +91,14 @@
         }
     }
 
-    static async Task SendAsync(string payload)
+    static async Task SendAsync(string payload, Cancel cancel)
     {
         try
         {
-            await InnerSendAsync(payload);
+            await InnerSendAsync(payload, cancel);
         }
-        catch (Exception exception)
+        // Let cancellation surface to the caller; only genuine send failures are swallowed.
+        catch (Exception exception) when (exception is not OperationCanceledException)
         {
             HandleSendException(payload, exception);
         }
@@ -132,16 +133,28 @@
         }
     }
 
-    static async Task InnerSendAsync(string payload)
+    static async Task InnerSendAsync(string payload, Cancel cancel)
     {
         using var client = new TcpClient();
         var endpoint = GetEndpoint();
         try
         {
-            await client.ConnectAsync(endpoint.Address, endpoint.Port);
+#if NET6_0_OR_GREATER
+            await client.ConnectAsync(endpoint.Address, endpoint.Port, cancel);
             using var stream = client.GetStream();
             using var writer = new StreamWriter(stream);
-            await writer.WriteAsync(payload);
+            await writer.WriteAsync(payload.AsMemory(), cancel);
+#else
+            cancel.ThrowIfCancellationRequested();
+            // Older frameworks lack cancellable Connect/Write, so abort by closing the client.
+            using (cancel.Register(client.Close))
+            {
+                await client.ConnectAsync(endpoint.Address, endpoint.Port);
+                using var stream = client.GetStream();
+                using var writer = new StreamWriter(stream);
+                await writer.WriteAsync(payload);
+            }
+#endif
         }
         finally
         {

--- a/src/DiffEngineTray.Tests/DiffRunnerCanKillTest.cs
+++ b/src/DiffEngineTray.Tests/DiffRunnerCanKillTest.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Net.Sockets;
+using DiffEngine;
+
+#pragma warning disable CS0618 // DiffEngineTray is obsolete; the test drives it directly to enable the send path.
+
+// Regression test for the sync launch path sending the wrong `canKill` value.
+// MDI tools host every diff in one shared window, so the tray must never kill them (CanKill=false);
+// non-MDI tools get their own process, which the tray may kill (CanKill=true).
+public class DiffRunnerCanKillTest :
+    IDisposable
+{
+    string tempFile = Path.GetTempFileName();
+    bool originalDisabled = DiffRunner.Disabled;
+    string? originalMaxInstances = Environment.GetEnvironmentVariable("DiffEngine_MaxInstances");
+
+    public DiffRunnerCanKillTest()
+    {
+        PiperClient.Port = GetFreePort();
+        DiffEngine.DiffEngineTray.IsRunning = true;
+        DiffRunner.Disabled = false;
+        // Force the "too many running" branch so no real process is launched, while a move
+        // payload is still sent to the tray. The env var takes precedence over the app-domain
+        // value, so set it too; MaxInstancesToLaunch resets the cached lookup.
+        Environment.SetEnvironmentVariable("DiffEngine_MaxInstances", "0");
+        DiffRunner.MaxInstancesToLaunch(0);
+    }
+
+    [Test]
+    public async Task Sync_launch_of_mdi_tool_marks_move_as_not_killable()
+    {
+        var received = await CaptureMove(() => Task.FromResult(DiffRunner.Launch(MdiTool(), tempFile, "target.txt")));
+
+        await Assert.That(received.CanKill).IsFalse();
+    }
+
+    [Test]
+    public async Task Async_launch_of_mdi_tool_marks_move_as_not_killable()
+    {
+        var received = await CaptureMove(() => DiffRunner.LaunchAsync(MdiTool(), tempFile, "target.txt"));
+
+        await Assert.That(received.CanKill).IsFalse();
+    }
+
+    [Test]
+    public async Task Sync_launch_of_non_mdi_tool_marks_move_as_killable()
+    {
+        var received = await CaptureMove(() => Task.FromResult(DiffRunner.Launch(NonMdiTool(), tempFile, "target.txt")));
+
+        await Assert.That(received.CanKill).IsTrue();
+    }
+
+    static async Task<MovePayload> CaptureMove(Func<Task<LaunchResult>> launch)
+    {
+        MovePayload? received = null;
+        var source = new CancelSource();
+        var server = PiperServer.Start(move => received = move, _ => { }, source.Token);
+        try
+        {
+            var result = await launch();
+            await Assert.That(result).IsEqualTo(LaunchResult.TooManyRunningDiffTools);
+
+            for (var i = 0; received == null && i < 50; i++)
+            {
+                await Task.Delay(100);
+            }
+        }
+        finally
+        {
+            await source.CancelAsync();
+            await server;
+        }
+
+        await Assert.That(received).IsNotNull();
+        return received!;
+    }
+
+    static ResolvedTool MdiTool() => Tool(isMdi: true);
+
+    static ResolvedTool NonMdiTool() => Tool(isMdi: false);
+
+    static ResolvedTool Tool(bool isMdi) =>
+        new(
+            name: "FakeCanKillTool",
+            exePath: Environment.ProcessPath!,
+            launchArguments: new(
+                Left: (temp, target) => $"\"{temp}\" \"{target}\"",
+                Right: (temp, target) => $"\"{target}\" \"{temp}\""),
+            isMdi: isMdi,
+            autoRefresh: false,
+            binaryExtensions: [],
+            requiresTarget: false,
+            supportsText: true,
+            useShellExecute: false);
+
+    static int GetFreePort()
+    {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        try
+        {
+            return ((IPEndPoint) probe.LocalEndpoint).Port;
+        }
+        finally
+        {
+            probe.Stop();
+        }
+    }
+
+    public void Dispose()
+    {
+        DiffEngine.DiffEngineTray.IsRunning = false;
+        DiffRunner.Disabled = originalDisabled;
+        Environment.SetEnvironmentVariable("DiffEngine_MaxInstances", originalMaxInstances);
+        DiffRunner.MaxInstancesToLaunch(5);
+        File.Delete(tempFile);
+    }
+}

--- a/src/DiffEngineTray.Tests/FileExTest.cs
+++ b/src/DiffEngineTray.Tests/FileExTest.cs
@@ -1,0 +1,31 @@
+public class FileExTest
+{
+    [Test]
+    public async Task SafeDeleteDirectoryRemovesDirectoryWithOnlyEmptySubDirectories()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "DiffEngineSafeDelete", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "sub", "nested"));
+
+        FileEx.SafeDeleteDirectory(root);
+
+        await Assert.That(Directory.Exists(root)).IsFalse();
+    }
+
+    [Test]
+    public async Task SafeDeleteDirectoryKeepsDirectoryThatContainsAFile()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "DiffEngineSafeDelete", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        await File.WriteAllTextAsync(Path.Combine(root, "keep.txt"), "data");
+        try
+        {
+            FileEx.SafeDeleteDirectory(root);
+
+            await Assert.That(Directory.Exists(root)).IsTrue();
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}

--- a/src/DiffEngineTray.Tests/PiperTest.SendOnly.verified.txt
+++ b/src/DiffEngineTray.Tests/PiperTest.SendOnly.verified.txt
@@ -14,9 +14,7 @@ Exception:
 System.Net.Sockets.SocketException (10061): No connection could be made because the target machine actively refused it.
    at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
    at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource.GetResult(Int16 token)
-   at System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
---- End of stack trace from previous location ---
-   at System.Net.Sockets.TcpClient.CompleteConnectAsync(Task task),
+   at System.Net.Sockets.TcpClient.CompleteConnectAsync(ValueTask task),
   Failed to send payload to DiffEngineTray.
 
 Payload:
@@ -29,7 +27,5 @@ Exception:
 System.Net.Sockets.SocketException (10061): No connection could be made because the target machine actively refused it.
    at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
    at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource.GetResult(Int16 token)
-   at System.Threading.Tasks.ValueTask.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
---- End of stack trace from previous location ---
-   at System.Net.Sockets.TcpClient.CompleteConnectAsync(Task task)
+   at System.Net.Sockets.TcpClient.CompleteConnectAsync(ValueTask task)
 ]

--- a/src/DiffEngineTray.Tests/PiperTest.cs
+++ b/src/DiffEngineTray.Tests/PiperTest.cs
@@ -85,6 +85,25 @@ public class PiperTest :
     }
 
     [Test]
+    public async Task SendMoveAsyncHonorsCancellation()
+    {
+        using var source = new CancelSource();
+        source.Cancel();
+
+        var cancelled = false;
+        try
+        {
+            await PiperClient.SendMoveAsync("Foo", "Bar", "theExe", "TheArguments", true, 10, source.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            cancelled = true;
+        }
+
+        await Assert.That(cancelled).IsTrue();
+    }
+
+    [Test]
     public async Task ClientDisconnectsAbruptly()
     {
         DeletePayload? received = null;

--- a/src/DiffEngineTray.Tests/ProcessExTest.cs
+++ b/src/DiffEngineTray.Tests/ProcessExTest.cs
@@ -14,4 +14,16 @@
         await Assert.That(ProcessEx.TryGet(40000, out var found)).IsFalse();
         await Assert.That(found).IsNull();
     }
+
+    [Test]
+    public async Task DescribeIsSafeForDisposedProcess()
+    {
+        var process = Process.GetCurrentProcess();
+        process.Dispose();
+
+        // Id/MainModule can throw on a disposed process; Describe must swallow that.
+        var description = ProcessEx.Describe(process);
+
+        await Assert.That(description).IsNotNull();
+    }
 }

--- a/src/DiffEngineTray.Tests/ProgramKeyBindingsTest.cs
+++ b/src/DiffEngineTray.Tests/ProgramKeyBindingsTest.cs
@@ -1,0 +1,40 @@
+public class ProgramKeyBindingsTest
+{
+    [Test]
+    public async Task Each_configured_hotkey_uses_a_distinct_binding_id()
+    {
+        var settings = new Settings
+        {
+            DiscardAllHotKey = new() { Key = "A" },
+            AcceptAllHotKey = new() { Key = "B" },
+            AcceptOpenHotKey = new() { Key = "C" },
+        };
+        await using var tracker = new RecordingTracker();
+
+        var ids = Program.BuildKeyBindings(settings, tracker)
+            .Select(_ => _.Id)
+            .ToList();
+
+        await Assert.That(ids.Count).IsEqualTo(3);
+        // A duplicate id would make KeyRegister unregister and overwrite an earlier hot key.
+        await Assert.That(ids.Distinct().Count()).IsEqualTo(3);
+        await Assert.That(ids.Contains(KeyBindingIds.DiscardAll)).IsTrue();
+        await Assert.That(ids.Contains(KeyBindingIds.AcceptAll)).IsTrue();
+        await Assert.That(ids.Contains(KeyBindingIds.AcceptOpen)).IsTrue();
+    }
+
+    [Test]
+    public async Task AcceptOpen_hotkey_maps_to_the_AcceptOpen_binding()
+    {
+        var settings = new Settings
+        {
+            AcceptOpenHotKey = new() { Key = "C" },
+        };
+        await using var tracker = new RecordingTracker();
+
+        var binding = Program.BuildKeyBindings(settings, tracker)
+            .Single();
+
+        await Assert.That(binding.Id).IsEqualTo(KeyBindingIds.AcceptOpen);
+    }
+}

--- a/src/DiffEngineTray.Tests/SolutionDirectoryFinderTests.cs
+++ b/src/DiffEngineTray.Tests/SolutionDirectoryFinderTests.cs
@@ -1,11 +1,39 @@
-#if DEBUG
 public class SolutionDirectoryFinderTests
 {
+#if DEBUG
     static string SourceFile { get; } = GetSourceFile();
     static string GetSourceFile([CallerFilePath] string path = "") => path;
 
     [Test]
     public Task Find() =>
         Verify(SolutionDirectoryFinder.Find(SourceFile));
-}
 #endif
+
+    [Test]
+    public async Task SiblingWithSharedPrefixIsNotMatched()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "DiffEngineSlnFinder", Guid.NewGuid().ToString("N"));
+        var appDir = Path.Combine(root, "App");
+        var appTestsDir = Path.Combine(root, "AppTests");
+        Directory.CreateDirectory(appDir);
+        Directory.CreateDirectory(appTestsDir);
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(appDir, "App.sln"), "");
+            await File.WriteAllTextAsync(Path.Combine(appTestsDir, "AppTests.sln"), "");
+
+            // Resolve a file inside App first so its directory gets cached.
+            var appResult = SolutionDirectoryFinder.Find(Path.Combine(appDir, "Class.cs"));
+            await Assert.That(appResult).IsEqualTo("App");
+
+            // A sibling that merely shares the "App" name prefix must resolve to its own
+            // solution, not to the cached "App" directory.
+            var testsResult = SolutionDirectoryFinder.Find(Path.Combine(appTestsDir, "Tests.cs"));
+            await Assert.That(testsResult).IsEqualTo("AppTests");
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}

--- a/src/DiffEngineTray/FileEx.cs
+++ b/src/DiffEngineTray/FileEx.cs
@@ -2,8 +2,8 @@ using IOException = System.IO.IOException;
 
 static class FileEx
 {
-    public static bool IsEmptyDirectory(string directory) =>
-        !Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories).Any();
+    public static bool ContainsFiles(string directory) =>
+        Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories).Any();
 
     public static bool SafeDeleteFile(string path)
     {
@@ -37,14 +37,16 @@ static class FileEx
             return;
         }
 
-        if (!IsEmptyDirectory(path))
+        // Leave the directory if it still holds files (a running test may be using them).
+        // Otherwise it is safe to remove the whole tree, including any empty sub-directories.
+        if (ContainsFiles(path))
         {
             return;
         }
 
         try
         {
-            Directory.Delete(path, false);
+            Directory.Delete(path, true);
         }
         catch (IOException exception)
         {

--- a/src/DiffEngineTray/ProcessEx.cs
+++ b/src/DiffEngineTray/ProcessEx.cs
@@ -31,13 +31,16 @@ static class ProcessEx
 
     public static void KillAndDispose(this Process process)
     {
+        // Capture identity up front. Once the process has exited, Id/MainModule can throw,
+        // so reading them in the error handlers below could mask the real failure.
+        var description = Describe(process);
         try
         {
             process.Kill();
             var exited = process.WaitForExit(500);
             if (!exited)
             {
-                ExceptionHandler.Handle($"Failed to kill process. Id:{process.Id} Name: {process.MainModule?.FileName}");
+                ExceptionHandler.Handle($"Failed to kill process. {description}");
             }
         }
         catch (InvalidOperationException)
@@ -51,11 +54,24 @@ static class ProcessEx
         }
         catch (Exception exception)
         {
-            ExceptionHandler.Handle($"Failed to kill process. Id:{process.Id} Name: {process.MainModule?.FileName}", exception);
+            ExceptionHandler.Handle($"Failed to kill process. {description}", exception);
         }
         finally
         {
             process.Dispose();
+        }
+    }
+
+    internal static string Describe(Process process)
+    {
+        try
+        {
+            return $"Id:{process.Id} Name: {process.MainModule?.FileName}";
+        }
+        catch (Exception)
+        {
+            // Id/MainModule can throw for an exited, disposed or inaccessible process.
+            return "Id: unknown";
         }
     }
 }

--- a/src/DiffEngineTray/Program.cs
+++ b/src/DiffEngineTray/Program.cs
@@ -84,44 +84,42 @@ static class Program
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "ShowContextMenu")]
     static extern void ShowContextMenu(NotifyIcon icon);
 
-    static void ReBindKeys(Settings settings, KeyRegister keyRegister, Tracker tracker)
+    internal static void ReBindKeys(Settings settings, KeyRegister keyRegister, Tracker tracker)
     {
-        var discardAllHotKey = settings.DiscardAllHotKey;
-        if (discardAllHotKey != null)
+        foreach (var binding in BuildKeyBindings(settings, tracker))
         {
+            var hotKey = binding.HotKey;
             keyRegister.TryAddBinding(
-                KeyBindingIds.DiscardAll,
-                discardAllHotKey.Shift,
-                discardAllHotKey.Control,
-                discardAllHotKey.Alt,
-                discardAllHotKey.Key,
-                tracker.Clear);
-        }
-
-        var acceptAllHotKey = settings.AcceptAllHotKey;
-        if (acceptAllHotKey != null)
-        {
-            keyRegister.TryAddBinding(
-                KeyBindingIds.AcceptAll,
-                acceptAllHotKey.Shift,
-                acceptAllHotKey.Control,
-                acceptAllHotKey.Alt,
-                acceptAllHotKey.Key,
-                tracker.AcceptAll);
-        }
-
-        var acceptOpenHotKey = settings.AcceptOpenHotKey;
-        if (acceptOpenHotKey != null)
-        {
-            keyRegister.TryAddBinding(
-                KeyBindingIds.AcceptAll,
-                acceptOpenHotKey.Shift,
-                acceptOpenHotKey.Control,
-                acceptOpenHotKey.Alt,
-                acceptOpenHotKey.Key,
-                tracker.AcceptOpen);
+                binding.Id,
+                hotKey.Shift,
+                hotKey.Control,
+                hotKey.Alt,
+                hotKey.Key,
+                binding.Action);
         }
     }
+
+    // Each configured hot key must map to a distinct KeyBindingIds value.
+    // Reusing an id causes KeyRegister.TryAddBinding to unregister and overwrite the earlier binding.
+    internal static IEnumerable<KeyBinding> BuildKeyBindings(Settings settings, Tracker tracker)
+    {
+        if (settings.DiscardAllHotKey is { } discardAll)
+        {
+            yield return new(KeyBindingIds.DiscardAll, discardAll, tracker.Clear);
+        }
+
+        if (settings.AcceptAllHotKey is { } acceptAll)
+        {
+            yield return new(KeyBindingIds.AcceptAll, acceptAll, tracker.AcceptAll);
+        }
+
+        if (settings.AcceptOpenHotKey is { } acceptOpen)
+        {
+            yield return new(KeyBindingIds.AcceptOpen, acceptOpen, tracker.AcceptOpen);
+        }
+    }
+
+    internal record KeyBinding(int Id, HotKey HotKey, Action Action);
 
     static async Task<Settings?> GetSettings()
     {

--- a/src/DiffEngineTray/SolutionDirectoryFinder.cs
+++ b/src/DiffEngineTray/SolutionDirectoryFinder.cs
@@ -13,12 +13,27 @@
 
     static Result? Inner(string file)
     {
-        foreach (var result in cache.Values.Where(_ => _ != null))
+        // Reuse an already resolved solution when the file sits inside its directory.
+        // Prefer the nearest (longest) enclosing directory so nested solutions resolve correctly.
+        Result? nearest = null;
+        foreach (var result in cache.Values)
         {
-            if (file.StartsWith(result!.Directory))
+            if (result == null ||
+                !IsInDirectory(file, result.Directory))
             {
-                return result;
+                continue;
             }
+
+            if (nearest == null ||
+                result.Directory.Length > nearest.Directory.Length)
+            {
+                nearest = result;
+            }
+        }
+
+        if (nearest != null)
+        {
+            return nearest;
         }
 
         var currentDirectory = Path.GetDirectoryName(file);
@@ -47,6 +62,25 @@
 
             currentDirectory = parent.FullName;
         } while (true);
+    }
+
+    // True when file is directory itself or sits below it, requiring a directory-separator
+    // boundary so that a sibling like "AppTests" is not treated as being inside "App".
+    static bool IsInDirectory(string file, string directory)
+    {
+        if (!file.StartsWith(directory, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (file.Length == directory.Length)
+        {
+            return true;
+        }
+
+        var boundary = file[directory.Length];
+        return boundary == Path.DirectorySeparatorChar ||
+               boundary == Path.AltDirectorySeparatorChar;
     }
 
     static bool TryFind(string directory, string searchPattern, [NotNullWhen(true)] out Result? result)


### PR DESCRIPTION
- DiffRunner: the sync launch path passed `tool.IsMdi` instead of `!tool.IsMdi` as `canKill` on the already-running and max-instance paths, diverging from the async path. For MDI tools (VS Code, Cursor, Visual Studio, Araxis) this could make the tray kill the shared editor when a diff is accepted/discarded; for non-MDI tools it left diff windows orphaned. Compute `canKill` once so the paths can't drift.
- Program.ReBindKeys: the "Accept Open" hotkey was registered under KeyBindingIds.AcceptAll, so configuring both it and "Accept All" silently disabled "Accept All". Route bindings through a single BuildKeyBindings mapping with the correct id.
- SolutionDirectoryFinder: the cached-prefix match had no directory-separator boundary, so a file under "AppTests" resolved to a cached "App" solution. Add a boundary check, make it case-insensitive, and prefer the nearest enclosing directory.
- PiperClient: the async sends accepted a cancellation token but never used it. Thread it through connect/write and let cancellation surface to the caller instead of being logged as a send failure.
- ProcessEx.KillAndDispose: the error handlers read Id/MainModule after the kill, which can throw and escape the method. Capture the process description up front.
- FileEx.SafeDeleteDirectory threw on a temp directory that contained only empty sub-directories (non-recursive delete). Delete recursively and rename the misleading `IsEmptyDirectory` (which only checked for files) to `ContainsFiles`.

Add regression tests for each.