### PR TITLE
Fix the two Linux tests the inline key change broke

### DIFF
--- a/src/DiffEngineViewer.Tests/IpcTests.List.verified.txt
+++ b/src/DiffEngineViewer.Tests/IpcTests.List.verified.txt
@@ -1,13 +1,13 @@
-﻿{
+{
   Ok: true,
   Items: [
     {
       Key: sampletests.cs|42,
-      Name: SampleTests.cs:42
+      Name: sampletests.cs:42
     },
     {
       Key: othertests.cs|7,
-      Name: OtherTests.cs:7
+      Name: othertests.cs:7
     }
   ]
 }

--- a/src/DiffEngineViewer.Tests/IpcTests.cs
+++ b/src/DiffEngineViewer.Tests/IpcTests.cs
@@ -72,12 +72,17 @@ public class IpcTests
         await Assert.That(fixture.Host.State.Queue.Count).IsEqualTo(1);
     }
 
+    /// <summary>
+    /// Lower case paths, so the key is the same text on every platform: it folds case only where
+    /// the file system does, and what this is pinning is the shape of a listing rather than which
+    /// of those the runner is. InlineKey has a test per platform of its own.
+    /// </summary>
     [Test]
     public Task List()
     {
         using var fixture = new ServerFixture();
-        fixture.Send(Inline(Fixtures.Patch()));
-        fixture.Send(Inline(Fixtures.Patch("OtherTests.cs", 7, null, "new")));
+        fixture.Send(Inline(Fixtures.Patch("sampletests.cs")));
+        fixture.Send(Inline(Fixtures.Patch("othertests.cs", 7, null, "new")));
 
         return Verify(fixture.Send(new(ViewerVerb.List)));
     }

--- a/src/DiffEngineViewer.Tests/ViewerSessionTests.cs
+++ b/src/DiffEngineViewer.Tests/ViewerSessionTests.cs
@@ -22,7 +22,13 @@ public class ViewerSessionTests
         await Assert.That(state.Queue[0].LeftText).IsEqualTo("second");
     }
 
+    /// <summary>
+    /// Two paths differing only in case are one file here, so they are one entry. macOS runs this
+    /// one too — RunOn takes a single platform, and the folding itself has a test per platform in
+    /// ViewerProtocolTests.
+    /// </summary>
     [Test]
+    [RunOn(TUnit.Core.Enums.OS.Windows)]
     public async Task EnqueueKeyIgnoresPathCase()
     {
         var state = Fixtures.Inline(
@@ -30,6 +36,21 @@ public class ViewerSessionTests
             Fixtures.Patch("a.CS", 1, "\"a\"", "second"));
 
         await Assert.That(state.Queue.Count).IsEqualTo(1);
+    }
+
+    /// <summary>
+    /// And two files where the file system says so, so two entries. One key for both meant the
+    /// second patch took over the first's entry and settling either settled both.
+    /// </summary>
+    [Test]
+    [RunOn(TUnit.Core.Enums.OS.Linux)]
+    public async Task EnqueueKeyKeepsPathCaseWhereTheFilesDo()
+    {
+        var state = Fixtures.Inline(
+            Fixtures.Patch("A.cs", 1, "\"a\"", "first"),
+            Fixtures.Patch("a.CS", 1, "\"a\"", "second"));
+
+        await Assert.That(state.Queue.Count).IsEqualTo(2);
     }
 
     [Test]


### PR DESCRIPTION
Both encoded the folding that is now platform dependent, and both are in DiffEngineViewer.Tests, which is the one test project the Linux legs of CI build. I checked DiffEngine.Tests for this and stopped there.

EnqueueKeyIgnoresPathCase asserts that two paths differing only in case are one entry, which is true where the file system says so and false on Linux. It is pinned to Windows now, with the Linux half beside it asserting the two entries that platform should give.

IpcTests.List snapshotted keys derived from mixed case paths, so the snapshot said which platform it ran on. Its paths are lower case now, so the key is the same text everywhere and the snapshot is back to pinning the shape of a listing.

Checked by forcing the folding off and running the viewer tests: List passes, and two case-differing paths do produce the two entries the new test expects.