### PR TITLE
Do not swallow a trailing comment into the argument

### DIFF
--- a/src/DiffEngine.Tests/InlinePatcherTests.cs
+++ b/src/DiffEngine.Tests/InlinePatcherTests.cs
@@ -123,6 +123,27 @@ public class InlinePatcherTests
     const string q3 = "\"\"\"";
     const string q4 = "\"\"\"\"";
 
+    /// <summary>
+    /// A comment between the argument and the closing paren. A line comment's span includes the
+    /// newline that ends it, so trimming trailing whitespace first ate that newline and the
+    /// comment then looked like part of the argument - which is not a string literal.
+    /// </summary>
+    [Test]
+    public async Task ATrailingCommentIsNotPartOfTheArgument()
+    {
+        var source = Method(
+            "        await Snapshot(\"old\" // note\n" +
+            "            );");
+
+        var status = TryApply(source, 5, InlinePatchMode.Set, "\"old\"", "new", out var newSource, out var reason);
+
+        await Assert.That(status).IsEqualTo(PatchStatus.Applied);
+        await Assert.That(reason).IsEmpty();
+        // The literal is replaced and the comment is left where it was, rather than being
+        // swallowed into the argument
+        await Assert.That(newSource).Contains("Snapshot(\"new\" // note");
+        await Assert.That(newSource).DoesNotContain("\"old\"");
+    }
     [Test]
     public async Task ReplaceRegularLiteral()
     {

--- a/src/DiffEngine/Inline/InlinePatcher.cs
+++ b/src/DiffEngine/Inline/InlinePatcher.cs
@@ -915,16 +915,19 @@ static class InlinePatcher
 
         while (end > start)
         {
-            if (char.IsWhiteSpace(source[end - 1]))
-            {
-                end--;
-                continue;
-            }
-
+            // The comment is asked about before the whitespace, because a line comment's span
+            // includes the newline that ends it. Trimming first ate that newline, after which
+            // nothing ended at `end` any more and the comment stayed inside the argument
             if (scan.TryGetCommentEndingAt(end, out var commentStart) &&
                 commentStart >= start)
             {
                 end = commentStart;
+                continue;
+            }
+
+            if (char.IsWhiteSpace(source[end - 1]))
+            {
+                end--;
                 continue;
             }
 


### PR DESCRIPTION
TrimSpan's trailing loop trimmed whitespace before asking whether a comment
ended where it was looking. A line comment's span includes the newline that ends
it, so the first thing trimmed was that newline - after which nothing ended at
`end` any more, the comment check never matched, and the comment stayed inside
the argument span.

The argument then was not a string literal, and the snapshot could not be
patched at all: "The expected argument of the Snapshot call near line N is not a
string literal", for a call that is perfectly ordinary apart from having a
comment after it.

Ask about the comment first. The two cases only collide when a comment ends
exactly where the scan is looking and the character before it is that comment's
own newline, which is precisely the shape that failed.
