### PR TITLE
Treat an inaccessible tray mutex as no tray

### DIFF
--- a/src/DiffEngine/Tray/DiffEngineTray.cs
+++ b/src/DiffEngine/Tray/DiffEngineTray.cs
@@ -17,6 +17,13 @@ public static class DiffEngineTray
         catch (IOException)
         {
         }
+        // A mutex that exists but is not accessible to this caller, which Mutex.TryOpenExisting
+        // documents: the tray under one account and the tests under another. Uncaught in a static
+        // constructor it is far worse than a wrong answer - the type never initialises, so every
+        // later DiffRunner.Launch and AddDelete in the process throws TypeInitializationException
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 
     public static bool IsRunning { get; internal set; }

--- a/src/DiffEngine/Tray/TrayDetector.cs
+++ b/src/DiffEngine/Tray/TrayDetector.cs
@@ -15,6 +15,13 @@
         catch (IOException)
         {
         }
+        // Documented for a mutex that exists but cannot be opened by this caller: the tray running
+        // under one account and the tests under another in the same session. "Not accessible" is
+        // not "not running", but from here there is nothing to tell them apart with, and the
+        // answer that keeps a diff tool launching is the one to take
+        catch (UnauthorizedAccessException)
+        {
+        }
 
         return false;
     }


### PR DESCRIPTION
Both mutex probes caught only IOException, for the documented macOS case where
opening a mutex that does not exist throws. Mutex.TryOpenExisting also documents
UnauthorizedAccessException, for a mutex that does exist but is not accessible
to this caller - the tray running under one account and the tests under another
in the same session, which is ordinary on a shared or elevated desktop.

"Not accessible" is not the same as "not running", but from inside the probe
there is nothing to tell them apart with, and the answer that keeps a diff tool
launching is the one to take.

The consequence in DiffEngineTray is out of proportion to the cause: that probe
is in a static constructor, so the exception becomes a TypeInitializationException
and every later DiffRunner.Launch and AddDelete in the process throws it, for
the life of the process.

No test. The condition needs a mutex owned by another account, which cannot be
arranged from inside the suite.
