### PR TITLE
Give the terminate tests a margin, without letting them stop failing

### DIFF
--- a/src/DiffEngine.Tests/WindowsProcessTests.cs
+++ b/src/DiffEngine.Tests/WindowsProcessTests.cs
@@ -142,8 +142,10 @@ public class WindowsProcessTests
 
             await Assert.That(result).IsTrue();
 
-            // Verify process exited gracefully
-            await Assert.That(process.WaitForExit(1000)).IsTrue();
+            // Generous, because the margin here is the runner's, not the product's: a windowed
+            // FakeDiffTool runs until something closes it, so waiting longer cannot turn a failure
+            // into a pass. One second was a bet on a two core runner being idle
+            await Assert.That(process.WaitForExit(30000)).IsTrue();
         }
         finally
         {
@@ -191,8 +193,12 @@ public class WindowsProcessTests
 
             await Assert.That(result).IsTrue();
 
-            // Verify process was terminated (should be immediate with forceful kill)
-            await Assert.That(process.WaitForExit(1000)).IsTrue();
+            // Waiting longer is not enough on its own here: this FakeDiffTool sleeps five seconds
+            // and then exits by itself, so a wait past that passes whether it was terminated or
+            // simply ran out. The exit code is what tells those apart - TryTerminateProcess passes
+            // -1 to TerminateProcess, and running out returns 0
+            await Assert.That(process.WaitForExit(30000)).IsTrue();
+            await Assert.That(process.ExitCode).IsNotEqualTo(0);
         }
         finally
         {


### PR DESCRIPTION
Both asserted WaitForExit(1000) after terminating a process. One second is a bet
on the runner being idle, and on a loaded two core Windows runner it is not: the
pair went red on main, and a re-run with no code change went green.

Widening alone would have been wrong for the non-windowed case. That
FakeDiffTool sleeps five seconds and then exits by itself, so any wait past five
seconds passes whether the process was terminated or merely ran out - the same
trap LaunchAndKill was in. So that one also asserts the exit code:
TryTerminateProcess passes -1 to TerminateProcess, and running out returns 0.

The windowed case needs no such guard, since a windowed FakeDiffTool runs until
something closes it. Waiting longer there cannot turn a failure into a pass.

Checked by making TryTerminateProcess skip the terminate: both tests fail, one
on the exit code and one on the wait.
