### PR TITLE
Expand the viewer's search directory on Linux and macOS

### DIFF
--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -316,7 +316,7 @@ DiffTools.UseOrder(DiffTool.DiffEngineViewer);
    "tempFile.txt" "targetFile.txt"
    ```
   * Scanned paths:
-    * `$HOME/.dotnet/tools/DiffEngineViewer`
+    * `%HOME%/.dotnet/tools/DiffEngineViewer`
     * `%PATH%DiffEngineViewer`
 
 #### Linux settings:
@@ -330,7 +330,7 @@ DiffTools.UseOrder(DiffTool.DiffEngineViewer);
    "tempFile.txt" "targetFile.txt"
    ```
   * Scanned paths:
-    * `$HOME/.dotnet/tools/DiffEngineViewer`
+    * `%HOME%/.dotnet/tools/DiffEngineViewer`
     * `%PATH%DiffEngineViewer`
 
 ### [Diffinity](https://truehumandesign.se/s_diffinity.php)

--- a/src/DiffEngine.Tests/SearchDirectoryExpansionTests.cs
+++ b/src/DiffEngine.Tests/SearchDirectoryExpansionTests.cs
@@ -1,0 +1,41 @@
+/// <summary>
+/// Search directories are written in the one syntax that gets expanded.
+/// <para>
+/// WildcardFileFinder expands with Environment.ExpandEnvironmentVariables, which only understands
+/// %NAME%. A directory written shell style with $HOME was passed through untouched, so it named a
+/// literal directory called "$HOME" and never matched - which is why a globally installed
+/// DiffEngineViewer was invisible on Linux and macOS whenever the bundled copy was absent.
+/// </para>
+/// </summary>
+public class SearchDirectoryExpansionTests
+{
+    [Test]
+    public async Task NoDefinitionUsesShellStyleExpansion()
+    {
+        var shellStyle = Definitions.Tools
+            .SelectMany(
+                definition => Directories(definition)
+                    .Where(_ => _.Contains('$'))
+                    .Select(_ => $"{definition.Tool}: {_}"))
+            .ToList();
+
+        await Assert.That(shellStyle).IsEmpty();
+    }
+
+    static IEnumerable<string> Directories(Definition definition)
+    {
+        var support = definition.OsSupport;
+        foreach (var settings in new[] { support.Windows, support.Linux, support.Osx })
+        {
+            if (settings == null)
+            {
+                continue;
+            }
+
+            foreach (var directory in settings.SearchDirectories)
+            {
+                yield return directory;
+            }
+        }
+    }
+}

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -181,7 +181,7 @@ DiffTools.UseOrder(DiffTool.DiffEngineViewer);
    "tempFile.txt" "targetFile.txt"
    ```
   * Scanned paths:
-    * `$HOME/.dotnet/tools/DiffEngineViewer`
+    * `%HOME%/.dotnet/tools/DiffEngineViewer`
     * `%PATH%DiffEngineViewer`
 
 #### Linux settings:
@@ -195,7 +195,7 @@ DiffTools.UseOrder(DiffTool.DiffEngineViewer);
    "tempFile.txt" "targetFile.txt"
    ```
   * Scanned paths:
-    * `$HOME/.dotnet/tools/DiffEngineViewer`
+    * `%HOME%/.dotnet/tools/DiffEngineViewer`
     * `%PATH%DiffEngineViewer`
 
 ### [Diffinity](https://truehumandesign.se/s_diffinity.php)

--- a/src/DiffEngine/Implementation/DiffEngineViewer.cs
+++ b/src/DiffEngine/Implementation/DiffEngineViewer.cs
@@ -23,11 +23,11 @@ static partial class Implementation
                 Linux: new(
                     "DiffEngineViewer",
                     launchArguments,
-                    SearchDirectories("$HOME/.dotnet/tools/")),
+                    SearchDirectories("%HOME%/.dotnet/tools/")),
                 Osx: new(
                     "DiffEngineViewer",
                     launchArguments,
-                    SearchDirectories("$HOME/.dotnet/tools/"))),
+                    SearchDirectories("%HOME%/.dotnet/tools/"))),
             UseShellExecute: false,
             // Console subsystem, so without this a window flashes on every launch.
             CreateNoWindow: true,


### PR DESCRIPTION
WildcardFileFinder expands with Environment.ExpandEnvironmentVariables, which
only understands %NAME%. The Linux and macOS entries were written shell style as
$HOME/.dotnet/tools/, so that string was passed through untouched and named a
literal directory called "$HOME" - which nothing has.

A globally installed DiffEngineViewer was therefore invisible on those
platforms. It only mattered when the bundled copy was absent, which is exactly
the case the dotnet tool install exists to cover.

The test asserts no definition anywhere uses the shell syntax, rather than this
one entry, since the mistake is easy to repeat and the two syntaxes look equally
plausible in a path.

Generated docs regenerated to match.
