### PR TITLE
Validate the path, not the parameter name

### DIFF
--- a/src/DiffEngine.Tests/GuardTests.cs
+++ b/src/DiffEngine.Tests/GuardTests.cs
@@ -1,0 +1,27 @@
+public class GuardTests
+{
+    /// <summary>
+    /// FileExists passed its arguments to AgainstEmpty the wrong way round, so the empty check was
+    /// run against the literal parameter name - which is never empty. An empty path therefore fell
+    /// through to "File not found. Path: " with no ParamName on it, naming nothing at all.
+    /// </summary>
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task FileExistsRejectsAnEmptyPathByName(string path)
+    {
+        var exception = await Assert.That(() => Guard.FileExists(path, "tempFile"))
+            .Throws<ArgumentNullException>();
+
+        await Assert.That(exception!.ParamName).IsEqualTo("tempFile");
+    }
+
+    [Test]
+    public async Task FileExistsStillReportsAMissingFile()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"missing{Guid.NewGuid():N}.txt");
+
+        await Assert.That(() => Guard.FileExists(missing, "tempFile"))
+            .Throws<ArgumentException>();
+    }
+}

--- a/src/DiffEngine/Guard.cs
+++ b/src/DiffEngine/Guard.cs
@@ -10,7 +10,9 @@
 
     public static void FileExists(string path, string argumentName)
     {
-        AgainstEmpty(argumentName, path);
+        // (value, name), not (name, value). Reversed, this validated the literal parameter name -
+        // never empty - so an empty path fell through to the message below with no ParamName on it
+        AgainstEmpty(path, argumentName);
         if (!File.Exists(path))
         {
             throw new ArgumentException($"File not found. Path: {path}");

--- a/src/DiffEngine/OsSettingsResolver.cs
+++ b/src/DiffEngine/OsSettingsResolver.cs
@@ -4,7 +4,10 @@ static class OsSettingsResolver
 
     static OsSettingsResolver()
     {
-        var pathVariable = Environment.GetEnvironmentVariable("PATH")!;
+        // An unset PATH is a NullReferenceException in a static constructor, and so permanent
+        // for the process. `env -i` and some service launchers really do start a process without
+        // one; nothing on PATH simply means no tool is found that way
+        var pathVariable = Environment.GetEnvironmentVariable("PATH") ?? "";
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {


### PR DESCRIPTION
Guard.FileExists called AgainstEmpty(argumentName, path) - arguments reversed,
so the empty check ran against the literal parameter name, which is never empty.
An empty path fell straight through to ArgumentException("File not found. Path:
") with no ParamName, which names neither the argument nor the file.

The same commit stops OsSettingsResolver dereferencing a null PATH. `env -i` and
some service launchers do start a process without one, and this runs in a static
constructor, so the NullReferenceException is permanent for the process. An
empty PATH just means no tool is found that way, which is a perfectly good
answer.

No test for the PATH half: it is read once by a type initialiser, so it cannot
be exercised twice in one process.
