### PR TITLE
Look for Cursor where its installer puts it

### DIFF
--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -1216,6 +1216,7 @@ DiffTools.UseOrder(DiffTool.Cursor);
    --diff "tempFile.txt" "targetFile.txt"
    ```
   * Scanned paths:
+    * `%LocalAppData%\Programs\cursor\Cursor.exe`
     * `%ProgramFiles%\Cursor\Cursor.exe`
     * `%ProgramW6432%\Cursor\Cursor.exe`
     * `%ProgramFiles(x86)%\Cursor\Cursor.exe`

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -1081,6 +1081,7 @@ DiffTools.UseOrder(DiffTool.Cursor);
    --diff "tempFile.txt" "targetFile.txt"
    ```
   * Scanned paths:
+    * `%LocalAppData%\Programs\cursor\Cursor.exe`
     * `%ProgramFiles%\Cursor\Cursor.exe`
     * `%ProgramW6432%\Cursor\Cursor.exe`
     * `%ProgramFiles(x86)%\Cursor\Cursor.exe`

--- a/src/DiffEngine/Implementation/Cursor.cs
+++ b/src/DiffEngine/Implementation/Cursor.cs
@@ -23,6 +23,10 @@ static partial class Implementation
                 Windows: new(
                     "Cursor.exe",
                     launchArguments,
+                    // The per user location first, because it is what Cursor's own installer
+                    // defaults to. Only %ProgramFiles% was listed, so an ordinary install was not
+                    // found at all unless the machine also had a system wide one
+                    @"%LocalAppData%\Programs\cursor\",
                     @"%ProgramFiles%\Cursor\"),
                 Linux: new(
                     "cursor",


### PR DESCRIPTION
Only %ProgramFiles%\Cursor\ was searched. Cursor's own installer defaults to a
per user install under %LocalAppData%\Programs\cursor\, so an ordinary
installation was not found unless the machine happened to also have a system
wide one. VS Code's definition already lists both locations for the same reason.

Additive: the existing directory is kept and the per user one is searched first,
so nothing that resolves today stops resolving.

Not verified against an install - I have no Cursor here - so this rests on the
documented layout rather than on having watched it resolve. One thing I
deliberately did not change on the same evidence: PathCommandName is still
Cursor.exe, while Cursor, being a VS Code fork, most likely ships a cursor.cmd
shim the way VS Code ships code.cmd. VS Code's definition uses the shim for both
names. If that holds for Cursor too then the PATH lookup here is still wrong,
and someone with it installed should check.
