### PR TITLE
Look for Sublime Merge inside its real bundle

### DIFF
--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -1365,6 +1365,7 @@ DiffTools.UseOrder(DiffTool.SublimeMerge);
    mergetool "tempFile.txt" "targetFile.txt"
    ```
   * Scanned paths:
+    * `/Applications/Sublime Merge.app/Contents/SharedSupport/bin/smerge`
     * `/Applications/smerge.app/Contents/MacOS/smerge`
     * `%PATH%smerge`
 

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -1230,6 +1230,7 @@ DiffTools.UseOrder(DiffTool.SublimeMerge);
    mergetool "tempFile.txt" "targetFile.txt"
    ```
   * Scanned paths:
+    * `/Applications/Sublime Merge.app/Contents/SharedSupport/bin/smerge`
     * `/Applications/smerge.app/Contents/MacOS/smerge`
     * `%PATH%smerge`
 

--- a/src/DiffEngine/Implementation/SublimeMerge.cs
+++ b/src/DiffEngine/Implementation/SublimeMerge.cs
@@ -27,6 +27,12 @@ static partial class Implementation
                 Osx: new(
                     "smerge",
                     launchArguments,
+                    // The bundle is "Sublime Merge.app", and the command line tool inside it lives
+                    // under SharedSupport/bin rather than MacOS - which holds the GUI binary. The
+                    // one path listed here named neither, so a Mac install was never found by
+                    // directory search and only resolved for someone who had put smerge on PATH
+                    // themselves
+                    "/Applications/Sublime Merge.app/Contents/SharedSupport/bin/",
                     "/Applications/smerge.app/Contents/MacOS/")),
             Notes: " * While SublimeMerge is not MDI, it is treated as MDI since it uses a single shared process to managing multiple windows. As such it is not possible to close a Sublime merge process for a specific diff. [Vote for this feature](https://github.com/sublimehq/sublime_merge/issues/1168)");
     }


### PR DESCRIPTION
The one macOS path listed was /Applications/smerge.app/Contents/MacOS/, which
names neither the bundle nor the directory the command line tool is in. The
bundle is "Sublime Merge.app", and smerge lives under Contents/SharedSupport/bin
- MacOS holds the GUI binary.

So a Mac install was never found by directory search, and resolved only for
someone who had put smerge on PATH themselves.

Additive: the correct path is searched first and the old one is kept, so nothing
that resolves today stops resolving.

Not verified against an install - no Mac here - so this rests on Sublime Merge's
documented layout rather than on having watched it resolve.
