### PR TITLE
Quote ExamDiff's pane titles

### DIFF
--- a/docs/diff-tool.md
+++ b/docs/diff-tool.md
@@ -397,11 +397,11 @@ DiffTools.UseOrder(DiffTool.ExamDiff);
 
   * Example target on left arguments:
    ```
-   "targetFile.txt" "tempFile.txt" /nh /diffonly /dn1:targetFile.txt /dn2:tempFile.txt
+   "targetFile.txt" "tempFile.txt" /nh /diffonly /dn1:"targetFile.txt" /dn2:"tempFile.txt"
    ```
   * Example target on right arguments:
    ```
-   "tempFile.txt" "targetFile.txt" /nh /diffonly /dn1:tempFile.txt /dn2:targetFile.txt
+   "tempFile.txt" "targetFile.txt" /nh /diffonly /dn1:"tempFile.txt" /dn2:"targetFile.txt"
    ```
   * Scanned paths:
     * `%ProgramFiles%\ExamDiff Pro*\ExamDiff.exe`

--- a/src/DiffEngine.Tests/diffTools.include.md
+++ b/src/DiffEngine.Tests/diffTools.include.md
@@ -262,11 +262,11 @@ DiffTools.UseOrder(DiffTool.ExamDiff);
 
   * Example target on left arguments:
    ```
-   "targetFile.txt" "tempFile.txt" /nh /diffonly /dn1:targetFile.txt /dn2:tempFile.txt
+   "targetFile.txt" "tempFile.txt" /nh /diffonly /dn1:"targetFile.txt" /dn2:"tempFile.txt"
    ```
   * Example target on right arguments:
    ```
-   "tempFile.txt" "targetFile.txt" /nh /diffonly /dn1:tempFile.txt /dn2:targetFile.txt
+   "tempFile.txt" "targetFile.txt" /nh /diffonly /dn1:"tempFile.txt" /dn2:"targetFile.txt"
    ```
   * Scanned paths:
     * `%ProgramFiles%\ExamDiff Pro*\ExamDiff.exe`

--- a/src/DiffEngine/Implementation/ExamDiff.cs
+++ b/src/DiffEngine/Implementation/ExamDiff.cs
@@ -6,14 +6,17 @@ static partial class Implementation
         {
             var tempTitle = Path.GetFileName(temp);
             var targetTitle = Path.GetFileName(target);
-            return $"\"{target}\" \"{temp}\" /nh /diffonly /dn1:{targetTitle} /dn2:{tempTitle}";
+            // Quoted, like the paths beside them and like WinMerge and VisualStudio do with
+            // the same titles. A snapshot name with a space in it - which a parameterised
+            // test produces routinely - otherwise splits into extra positional arguments
+            return $"\"{target}\" \"{temp}\" /nh /diffonly /dn1:\"{targetTitle}\" /dn2:\"{tempTitle}\"";
         }
 
         static string RightArguments(string temp, string target)
         {
             var tempTitle = Path.GetFileName(temp);
             var targetTitle = Path.GetFileName(target);
-            return $"\"{temp}\" \"{target}\" /nh /diffonly /dn1:{tempTitle} /dn2:{targetTitle}";
+            return $"\"{temp}\" \"{target}\" /nh /diffonly /dn1:\"{tempTitle}\" /dn2:\"{targetTitle}\"";
         }
 
         return new(


### PR DESCRIPTION
The two paths were quoted and the /dn1 and /dn2 titles beside them were not,
even though both come from the same file names. A snapshot name containing a
space - which a parameterised test produces as a matter of course - therefore
split at the space and the remainder arrived as extra positional arguments.

WinMerge and VisualStudio quote the same titles.
