### PR TITLE
Leave the window command for a surface that has a window

### DIFF
--- a/src/DiffEngineTray.Tests/OwnedInlineHostTest.cs
+++ b/src/DiffEngineTray.Tests/OwnedInlineHostTest.cs
@@ -214,6 +214,30 @@ public class OwnedInlineHostTest
         await Assert.That(second.Window).IsNull();
     }
 
+    /// <summary>
+    /// A plain List does not take the stashed window command. It is the documented IDE plugin API
+    /// - InlineQueueClient.TryListKeys - and has no window to raise, so taking the command threw
+    /// it away: whoever asked could not act on it, and the attached viewer polling beside it never
+    /// raised for the new snapshot.
+    /// </summary>
+    [Test]
+    public async Task APlainListingLeavesTheWindowCommandForAViewer()
+    {
+        using var owner = new Owner();
+        owner.Queue();
+        var snapshot = owner.Host.List().Single();
+
+        owner.Host.Focus(snapshot);
+
+        var plain = owner.Send(new(ViewerVerb.List));
+        await Assert.That(plain.Window).IsNull();
+
+        // Still there for the surface that has a window
+        var full = owner.Send(new(ViewerVerb.ListFull));
+        await Assert.That(full.Window).IsEqualTo(WindowCommand.Focus);
+        await Assert.That(full.WindowKey).IsEqualTo(snapshot.Key);
+    }
+
     [Test]
     public async Task ClosingTheViewerLeavesTheQueue()
     {

--- a/src/DiffEngineTray/OwnedInlineHost.cs
+++ b/src/DiffEngineTray/OwnedInlineHost.cs
@@ -217,11 +217,25 @@ sealed class OwnedInlineHost :
 
             // Taken rather than read, so a focus happens once, on whichever viewer refreshes
             // first, rather than five times a second forever.
-            var command = window;
-            var key = windowKey;
-            window = null;
-            windowKey = null;
-            return ViewerResponse.Listing(items, command, key, moves, deletes);
+            //
+            // Only for a listing that carries patches, which is the one a viewer asks for. A plain
+            // List is the documented IDE plugin API - InlineQueueClient.TryListKeys - and has no
+            // window to raise, so handing it the stashed command threw the command away: the
+            // attached viewer polling beside it never raised for the new snapshot, and the plugin
+            // did nothing with what it was given.
+            ViewerResponse response;
+            if (withPatches)
+            {
+                response = ViewerResponse.Listing(items, window, windowKey, moves, deletes);
+                window = null;
+                windowKey = null;
+            }
+            else
+            {
+                response = ViewerResponse.Listing(items, null, null, moves, deletes);
+            }
+
+            return response;
         }
     }
 


### PR DESCRIPTION
The stashed Focus or Close was taken by whichever listing arrived first,
including a plain List. That one is the documented IDE plugin API -
InlineQueueClient.TryListKeys - and has no window to raise, so taking the
command threw it away: the plugin could do nothing with what it was handed, and
the attached viewer polling beside it never raised for the new snapshot.

Only a listing that carries patches takes it, which is the one a viewer asks
for. A plain listing now reads through without clearing the stash.
