### PR TITLE
Let Options open at any max instances that can be set

### DIFF
--- a/src/DiffEngineTray.Tests/OptionsFormMaxInstancesTests.cs
+++ b/src/DiffEngineTray.Tests/OptionsFormMaxInstancesTests.cs
@@ -1,0 +1,27 @@
+using NumericUpDown = System.Windows.Forms.NumericUpDown;
+
+/// <summary>
+/// The form's range has to be the setting's range. DiffEngine_MaxInstances takes any ushort, and
+/// the spinner was left at NumericUpDown's default maximum of 100, so anything above that threw
+/// out of the constructor and Options could never be opened to lower it again.
+/// </summary>
+[TUnit.Core.Executors.STAThreadExecutor]
+public class OptionsFormMaxInstancesTests
+{
+    [Test]
+    public async Task Opens_at_the_highest_max_instances_that_can_be_set()
+    {
+        using var form = new OptionsForm(
+            new()
+            {
+                MaxInstancesToLaunch = ushort.MaxValue
+            },
+            _ => Task.FromResult<IReadOnlyCollection<string>>([]));
+
+        var spinner = form.Controls
+            .Find("maxInstancesNumericUpDown", true)
+            .OfType<NumericUpDown>()
+            .Single();
+        await Assert.That(spinner.Value).IsEqualTo(ushort.MaxValue);
+    }
+}

--- a/src/DiffEngineTray/Settings/OptionsForm.Designer.cs
+++ b/src/DiffEngineTray/Settings/OptionsForm.Designer.cs
@@ -256,6 +256,16 @@
         this.maxInstancesNumericUpDown.Dock = System.Windows.Forms.DockStyle.Left;
         this.maxInstancesNumericUpDown.Location = new System.Drawing.Point(5, 44);
         this.maxInstancesNumericUpDown.Margin = new System.Windows.Forms.Padding(5);
+        // ushort.MaxValue, which is what MaxInstance accepts. Left at the default 100, a
+        // DiffEngine_MaxInstances above that threw out of this form's constructor, so Options
+        // could never be opened to lower it again.
+        this.maxInstancesNumericUpDown.Maximum = new decimal(new int[]
+        {
+            65535,
+            0,
+            0,
+            0
+        });
         this.maxInstancesNumericUpDown.Minimum = new decimal(new int[]
         {
             0,


### PR DESCRIPTION
maxInstancesNumericUpDown was left at NumericUpDown's default Maximum of 100 while
MaxInstance takes any ushort, so DiffEngine_MaxInstances=500 made the OptionsForm
constructor throw ArgumentOutOfRangeException on the line that shows the current
value - and Options is where that value would have been lowered again, so the tray
was stuck with it until the environment variable was edited by hand.

The spinner's range is now the range the setting has.
