### PR TITLE
Read Disabled when it is asked for rather than at type initialisation

### DIFF
--- a/src/DiffEngine.Tests/DisabledTests.cs
+++ b/src/DiffEngine.Tests/DisabledTests.cs
@@ -1,0 +1,38 @@
+/// <summary>
+/// <see cref="DiffRunner.Disabled" /> was captured at type initialisation, so a build server or AI
+/// CLI reported after that - which is when a test host reports one, having only just loaded - left
+/// diff tools launching anyway.
+/// </summary>
+[NotInParallel]
+public class DisabledTests
+{
+    [Test]
+    public async Task A_build_server_detected_after_first_use_still_disables()
+    {
+        // As the module initializer left it, and as any consumer that ever set it leaves it
+        DiffRunner.Disabled = false;
+
+        DiffRunner.ResetDisabled();
+        BuildServerDetector.Detected = true;
+
+        await Assert.That(DiffRunner.Disabled).IsTrue();
+    }
+
+    [Test]
+    public async Task Setting_it_pins_it()
+    {
+        DiffRunner.ResetDisabled();
+        BuildServerDetector.Detected = true;
+
+        DiffRunner.Disabled = false;
+
+        await Assert.That(DiffRunner.Disabled).IsFalse();
+    }
+
+    /// <summary>
+    /// Every other test in this assembly runs with it off, which the module initializer does once.
+    /// </summary>
+    [After(Test)]
+    public void Restore() =>
+        DiffRunner.Disabled = false;
+}

--- a/src/DiffEngine/DiffRunner.cs
+++ b/src/DiffEngine/DiffRunner.cs
@@ -6,7 +6,33 @@ namespace DiffEngine;
 /// </summary>
 public static partial class DiffRunner
 {
-    public static bool Disabled { get; set; } = DisabledChecker.IsDisable();
+    /// <summary>
+    /// Whether launching a diff tool is turned off, for this process or for this async context.
+    /// <para>
+    /// Read rather than captured, so that the overrides feeding it - <see cref="BuildServerDetector.Detected" />
+    /// and <see cref="AiCliDetector.Detected" />, both of which a test host sets after it has
+    /// loaded - are honoured whenever they are set. Captured once at type initialisation, they
+    /// were inert the moment anything had touched this class, and an AsyncLocal override could
+    /// never have reached a value read into a static anyway.
+    /// </para>
+    /// <para>
+    /// Setting it pins it, and nothing is read from the environment after that.
+    /// </para>
+    /// </summary>
+    public static bool Disabled
+    {
+        get => disabled ?? DisabledChecker.IsDisable();
+        set => disabled = value;
+    }
+
+    static bool? disabled;
+
+    /// <summary>
+    /// Forgets an explicit <see cref="Disabled" />, so it is read from the environment again. For
+    /// tests, which is where anything sets it and then wants the detectors back.
+    /// </summary>
+    internal static void ResetDisabled() =>
+        disabled = null;
 
     public static void MaxInstancesToLaunch(int value) =>
         MaxInstance.SetForAppDomain(value);


### PR DESCRIPTION
DiffRunner.Disabled captured DisabledChecker.IsDisable() in its initialiser, so
whichever of the detectors reported first won for the life of the process. Setting
BuildServerDetector.Detected or AiCliDetector.Detected after anything had touched
DiffRunner did nothing at all - and a test host sets them after it has loaded,
which is the only moment it can. BuildServerDetector.Detected is an AsyncLocal
override on top of that, and a per-context value could never have reached a static
captured once anyway.

It is computed on read now, and an explicit set still pins it: consumers that
assign Disabled keep the value they assigned, and nothing is read from the
environment after that.
