### PR TITLE
Tell two tracked files with one name apart

### DIFF
--- a/src/DiffEngineViewer.Tests/TrackedLabelTests.cs
+++ b/src/DiffEngineViewer.Tests/TrackedLabelTests.cs
@@ -1,0 +1,82 @@
+/// <summary>
+/// Labels for tracked moves and deletes. One verified file name in two projects of a solution is
+/// the ordinary case - every project has a SampleTests with a sample.verified.txt - and the label
+/// is the only thing on the row.
+/// </summary>
+public class TrackedLabelTests
+{
+    [Test]
+    public async Task Two_moves_of_one_file_name_are_told_apart()
+    {
+        var state = Tracked(
+            Move("ProjectA"),
+            Move("ProjectB"));
+
+        await Assert.That(Labels(state)).IsEquivalentTo(
+        [
+            "ProjectA/sample.verified.txt",
+            "ProjectB/sample.verified.txt"
+        ]);
+    }
+
+    [Test]
+    public async Task Two_deletes_of_one_file_name_are_told_apart()
+    {
+        var state = Tracked(
+            Delete("ProjectA"),
+            Delete("ProjectB"));
+
+        await Assert.That(Labels(state)).IsEquivalentTo(
+        [
+            "ProjectA/extra.verified.txt",
+            "ProjectB/extra.verified.txt"
+        ]);
+    }
+
+    /// <summary>
+    /// A name that is already distinct is left as it is: the label is the shortest form that tells
+    /// one entry from another, and the path is what the tooltip is for.
+    /// </summary>
+    [Test]
+    public async Task One_move_keeps_its_bare_name()
+    {
+        var state = Tracked(Move("ProjectA"));
+
+        await Assert.That(Labels(state)).IsEquivalentTo(["sample.verified.txt"]);
+    }
+
+    static IReadOnlyList<string> Labels(SessionState state) =>
+        QueueProjection.Rows(state)
+            .Where(_ => _.Kind == QueueRowKind.Entry)
+            .Select(_ => _.Label.Trim())
+            .ToList();
+
+    static SessionState Tracked(params QueueEntry[] entries)
+    {
+        var state = SessionState.Start(ViewerMode.Inline, Fixtures.Columns, Fixtures.Rows);
+        foreach (var entry in entries)
+        {
+            state = ViewerSession.EnqueueTracked(state, entry);
+        }
+
+        return state;
+    }
+
+    static QueueEntry Move(string project) =>
+        QueueEntry.ForMove(
+            $"move:{project}",
+            "sample.verified.txt",
+            "SolutionA",
+            $"temp/{project}/sample.received.txt",
+            $"code/SolutionA/{project}/sample.verified.txt",
+            FileSide.OfText("received"),
+            FileSide.OfText("expected"));
+
+    static QueueEntry Delete(string project) =>
+        QueueEntry.ForDelete(
+            $"delete:{project}",
+            "extra.verified.txt",
+            "SolutionA",
+            $"code/SolutionA/{project}/extra.verified.txt",
+            FileSide.OfText("expected"));
+}

--- a/src/DiffEngineViewer/QueueProjection.cs
+++ b/src/DiffEngineViewer/QueueProjection.cs
@@ -329,6 +329,20 @@ static class QueueProjection
             : null;
 
     /// <summary>
+    /// The path an entry's label can be grown from: the source file for an inline entry, and the
+    /// file a tracked one is about. Tracked entries used to have none, so two verified files with
+    /// the same name in two projects of one solution were left showing the same label.
+    /// </summary>
+    static string? LabelPath(QueueEntry entry) =>
+        entry.Kind switch
+        {
+            QueueEntryKind.Inline => entry.Patch?.SourceFile,
+            QueueEntryKind.Move => entry.TargetFile ?? entry.LeftFile,
+            QueueEntryKind.Delete => entry.LeftFile,
+            _ => null
+        };
+
+    /// <summary>
     /// The label an entry shows when it stands alone: the test name when one is known, else the
     /// call site or the tracked file name. Collisions within a solution — the same file name and
     /// line in two projects, or the same test name in two files — grow the shortest
@@ -357,7 +371,7 @@ static class QueueProjection
             {
                 var entry = entries[index];
                 var baseLabel = entry.TestName ?? entry.Name;
-                labels[index] = WithDirectories(entry.Patch!.SourceFile, baseLabel, depth);
+                labels[index] = WithDirectories(LabelPath(entry)!, baseLabel, depth);
             }
         }
 
@@ -367,7 +381,7 @@ static class QueueProjection
         foreach (var index in Collisions(entries, labels))
         {
             var entry = entries[index];
-            labels[index] = $"{entry.TestName ?? entry.Name} ({Path.GetFileName(entry.Patch!.SourceFile)})";
+            labels[index] = $"{entry.TestName ?? entry.Name} ({Path.GetFileName(LabelPath(entry)!)})";
         }
 
         return labels;
@@ -378,7 +392,7 @@ static class QueueProjection
         var collisions = new List<int>();
         for (var index = 0; index < entries.Count; index++)
         {
-            if (entries[index] is not { Kind: QueueEntryKind.Inline, Patch: not null })
+            if (LabelPath(entries[index]) is null)
             {
                 continue;
             }


### PR DESCRIPTION
The label a queue row shows grows a directory prefix when two rows in a solution
would otherwise read the same. Only inline entries were considered for it, because
the prefix came from the patch's source file and a tracked entry has no patch. So
two pending moves of sample.verified.txt, one per project, both showed
"sample.verified.txt" - which is the ordinary case, every project having a
SampleTests, and the label is the whole row.

The path a label grows from is now the file the entry is about: the source for an
inline entry, the target of a move, the file a delete is for.
