### PR TITLE
Load the committed linux-x64 binary somewhere

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,9 +193,15 @@ jobs:
           # dylib, so loading it here covers the arm64 slice and the step below checks that the
           # x86_64 slice is present.
           #
+          # linux-x64 is here because it is the RID most people run and nothing else loads its
+          # committed binary: the Ubuntu job above overwrites that file with a fresh build before
+          # testing, so a linux-x64 rebuild that was never merged would have shipped unnoticed.
+          #
           # No Windows entry either, since that head renders with WinForms and loads nothing.
           - rid: osx-arm64
             os: macos-14
+          - rid: linux-x64
+            os: ubuntu-24.04
           - rid: linux-arm64
             os: ubuntu-24.04-arm
     steps:


### PR DESCRIPTION
The native job exists to test what actually ships, because both test jobs build the
shim from source and overwrite the committed binary before testing. Its matrix held
osx-arm64 and linux-arm64 only, so the one RID it left out - linux-x64, the one most
people run - was loaded by no job at all. A rebuild that was never merged, a file
corrupted by a text mode checkout, or an unsatisfied runtime dependency would have
shipped unnoticed there, which is the exact class of failure the job's own comment
says it is for.
