### PR TITLE
Show the tray icon 40ms sooner

### DIFF
--- a/src/DiffEngineTray.Tests/SettingsHelperTests.cs
+++ b/src/DiffEngineTray.Tests/SettingsHelperTests.cs
@@ -63,7 +63,7 @@ public class SettingsHelperTests
                     AlwaysKillLockingProcesses = true
                 });
 
-            var result = await SettingsHelper.Read();
+            var result = SettingsHelper.Read();
 
             await Verify(result);
         }

--- a/src/DiffEngineTray/Images/Images.cs
+++ b/src/DiffEngineTray/Images/Images.cs
@@ -1,43 +1,58 @@
+/// <summary>
+/// Decoded on first use rather than all together.
+/// <para>
+/// A static constructor decoded all eleven the moment anything touched one, and the first thing to
+/// touch one is the tray icon - before the icon exists, so the cost is time the user spends looking
+/// at an empty notification area. Only <see cref="Default" /> is wanted then. Of the nine menu
+/// images, four are on the fixed menu items and five are only ever shown when something is pending,
+/// so most of that decoding was for a menu that may never have anything in it.
+/// </para>
+/// <para>
+/// The <see cref="Lazy{T}" /> fields still initialise together, which is fine: constructing one
+/// allocates and nothing more. Thread safe by default, and it has to be, because the icon is set
+/// from the scan timer as well as from the UI thread.
+/// </para>
+/// </summary>
 public static class Images
 {
+    public static Icon Active => active.Value;
+    public static Icon Default => defaultIcon.Value;
+    public static Image Exit => exit.Value;
+    public static Image Delete => delete.Value;
+    public static Image AcceptAll => acceptAll.Value;
+    public static Image Accept => accept.Value;
+    public static Image Discard => discard.Value;
+    public static Image VisualStudio => visualStudio.Value;
+    public static Image Folder => folder.Value;
+    public static Image Options => options.Value;
+    public static Image Link => link.Value;
+
+    static Lazy<Icon> active = LazyIcon("active.ico");
+    static Lazy<Icon> defaultIcon = LazyIcon("default.ico");
+    static Lazy<Image> exit = LazyImage("exit.png");
+    static Lazy<Image> delete = LazyImage("delete.png");
+    static Lazy<Image> acceptAll = LazyImage("acceptAll.png");
+    static Lazy<Image> accept = LazyImage("accept.png");
+    static Lazy<Image> discard = LazyImage("discard.png");
+    static Lazy<Image> visualStudio = LazyImage("vs.png");
+    static Lazy<Image> folder = LazyImage("folder.png");
+    static Lazy<Image> options = LazyImage("cogs.png");
+    static Lazy<Image> link = LazyImage("link.png");
+
+    static Lazy<Icon> LazyIcon(string name) =>
+        new(() =>
+        {
+            using var stream = GetStream(name);
+            return new Icon(stream);
+        });
+
+    static Lazy<Image> LazyImage(string name) =>
+        new(() =>
+        {
+            using var stream = GetStream(name);
+            return Image.FromStream(stream);
+        });
+
     static Stream GetStream(string name) =>
         Assembly.GetExecutingAssembly().GetManifestResourceStream($"DiffEngineTray.Images.{name}")!;
-
-    static Images()
-    {
-        using var activeStream = GetStream("active.ico");
-        Active = new(activeStream);
-        using var defaultStream = GetStream("default.ico");
-        Default = new(defaultStream);
-        using var exitStream = GetStream("exit.png");
-        Exit = Image.FromStream(exitStream);
-        using var deleteStream = GetStream("delete.png");
-        Delete = Image.FromStream(deleteStream);
-        using var acceptAllStream = GetStream("acceptAll.png");
-        AcceptAll = Image.FromStream(acceptAllStream);
-        using var acceptStream = GetStream("accept.png");
-        Accept = Image.FromStream(acceptStream);
-        using var discardStream = GetStream("discard.png");
-        Discard = Image.FromStream(discardStream);
-        using var vsStream = GetStream("vs.png");
-        VisualStudio = Image.FromStream(vsStream);
-        using var folderStream = GetStream("folder.png");
-        Folder = Image.FromStream(folderStream);
-        using var optionsStream = GetStream("cogs.png");
-        Options = Image.FromStream(optionsStream);
-        using var linkStream = GetStream("link.png");
-        Link = Image.FromStream(linkStream);
-    }
-
-    public static Image VisualStudio { get; }
-    public static Image Link { get; }
-    public static Image Discard { get; }
-    public static Image Accept { get; }
-    public static Image AcceptAll { get; }
-    public static Image Delete { get; }
-    public static Image Exit { get; }
-    public static Image Folder { get; }
-    public static Image Options { get; }
-    public static Icon Active { get; }
-    public static Icon Default { get; }
 }

--- a/src/DiffEngineTray/LockedFilesHandler.cs
+++ b/src/DiffEngineTray/LockedFilesHandler.cs
@@ -26,7 +26,7 @@ static class LockedFilesHandler
         {
             try
             {
-                var settings = await SettingsHelper.Read();
+                var settings = SettingsHelper.Read();
                 settings.AlwaysKillLockingProcesses = true;
                 await SettingsHelper.Write(settings);
             }

--- a/src/DiffEngineTray/Program.cs
+++ b/src/DiffEngineTray/Program.cs
@@ -56,7 +56,7 @@ static class Program
         void Warn(string message) =>
             icon.ShowBalloonTip(10000, "DiffEngineTray", message, ToolTipIcon.Warning);
 
-        var settings = await GetSettings();
+        var settings = GetSettings();
         if (settings == null)
         {
             return;
@@ -181,11 +181,11 @@ static class Program
 
     internal record KeyBinding(int Id, HotKey HotKey, Action Action);
 
-    static async Task<Settings?> GetSettings()
+    static Settings? GetSettings()
     {
         try
         {
-            return await SettingsHelper.Read();
+            return SettingsHelper.Read();
         }
         catch (Exception exception)
         {

--- a/src/DiffEngineTray/Program.cs
+++ b/src/DiffEngineTray/Program.cs
@@ -23,16 +23,6 @@ static class Program
 
     static async Task Inner()
     {
-        var settings = await GetSettings();
-        if (settings == null)
-        {
-            return;
-        }
-
-        LockedFilesHandler.AlwaysKill = settings.AlwaysKillLockingProcesses;
-
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(false);
         var tokenSource = new CancelSource();
         var cancel = tokenSource.Token;
         using var mutex = new Mutex(true, "DiffEngine", out var createdNew);
@@ -52,6 +42,10 @@ static class Program
             Log.Error(exception, "Failed to write the tray version marker");
         }
 
+        // Before the settings file rather than after it, because nothing between here and the
+        // first use of a setting needs one, and until this line the user is looking at an empty
+        // notification area. Still after the mutex, so a second instance exits without ever
+        // showing an icon.
         using var icon = new NotifyIcon
         {
             Icon = Images.Default,
@@ -61,6 +55,14 @@ static class Program
 
         void Warn(string message) =>
             icon.ShowBalloonTip(10000, "DiffEngineTray", message, ToolTipIcon.Warning);
+
+        var settings = await GetSettings();
+        if (settings == null)
+        {
+            return;
+        }
+
+        LockedFilesHandler.AlwaysKill = settings.AlwaysKillLockingProcesses;
 
         // Ownership of the inline queue is decided here, once, by whether the bind succeeds, and
         // never transfers. Usually the tray wins, because it starts at login. A viewer that was

--- a/src/DiffEngineTray/Settings/OptionsFormLauncher.cs
+++ b/src/DiffEngineTray/Settings/OptionsFormLauncher.cs
@@ -10,7 +10,7 @@ static class OptionsFormLauncher
             return;
         }
 
-        var settings = await SettingsHelper.Read();
+        var settings = SettingsHelper.Read();
         using var form = new OptionsForm(
             settings,
             newSettings => Save(keyRegister, tracker, settings, newSettings));

--- a/src/DiffEngineTray/Settings/SettingsContext.cs
+++ b/src/DiffEngineTray/Settings/SettingsContext.cs
@@ -1,0 +1,20 @@
+/// <summary>
+/// Source generated serialisation for <see cref="Settings" />, rather than the reflection based
+/// serialiser.
+/// <para>
+/// Worth less than it looks. Reading the settings file cost 31ms of a 200ms start, and moving the
+/// metadata to compile time took 4ms off that. Almost all of the rest is System.Text.Json being
+/// loaded and jitted for the first time, which no amount of generated code avoids - the file
+/// itself is under 200 bytes. Kept because it is strictly cheaper, and because it keeps the
+/// reflection based serialiser off the startup path altogether, which is the part that grows on a
+/// cold start.
+/// </para>
+/// <para>
+/// Both directions go through it, so a save does not reach the reflection based serialiser either.
+/// The written JSON is unchanged: the generator's defaults are the same defaults, which is what
+/// <c>SettingsHelperTests.ReadWrite</c> pins.
+/// </para>
+/// </summary>
+[JsonSerializable(typeof(Settings))]
+partial class SettingsContext :
+    JsonSerializerContext;

--- a/src/DiffEngineTray/Settings/SettingsHelper.cs
+++ b/src/DiffEngineTray/Settings/SettingsHelper.cs
@@ -10,7 +10,7 @@ static class SettingsHelper
         FilePath = Path.Combine(directory, "settings.json");
     }
 
-    public static async Task<Settings> Read()
+    public static Settings Read()
     {
         Settings settings;
         if (File.Exists(FilePath))
@@ -25,7 +25,7 @@ static class SettingsHelper
         }
         else
         {
-            await File.WriteAllTextAsync(FilePath, "{}");
+            File.WriteAllText(FilePath, "{}");
             settings = new();
         }
 

--- a/src/DiffEngineTray/Settings/SettingsHelper.cs
+++ b/src/DiffEngineTray/Settings/SettingsHelper.cs
@@ -15,8 +15,13 @@ static class SettingsHelper
         Settings settings;
         if (File.Exists(FilePath))
         {
-            await using var stream = File.OpenRead(FilePath);
-            settings = (await JsonSerializer.DeserializeAsync<Settings>(stream))!;
+            // Read whole and parsed in one go rather than deserialised off an async FileStream.
+            // The file is under 200 bytes, so the async machinery cost more than the read did:
+            // 27ms for the call against 21ms without it. What is left is System.Text.Json being
+            // loaded and jitted for the first time, which nothing here can avoid - see
+            // <see cref="SettingsContext"/>.
+            var json = File.ReadAllBytes(FilePath);
+            settings = JsonSerializer.Deserialize(json, SettingsContext.Default.Settings)!;
         }
         else
         {
@@ -52,7 +57,7 @@ static class SettingsHelper
 
         await using (var stream = File.Create(temp))
         {
-            await JsonSerializer.SerializeAsync(stream, settings);
+            await JsonSerializer.SerializeAsync(stream, settings, SettingsContext.Default.Settings);
         }
 
         await Swap(temp);


### PR DESCRIPTION
The tray icon appeared 121 ms into a warm start, and most of what came before it was work nothing about the icon needed. Measured from process start with probes at each step:

| step | before | after |
|---|---|---|
| .NET host → `Main` | 23 | 29 |
| `TrayViewerDirectory.Register` | 8 | 2 |
| `Logging.Init` | 23 | 23 |
| WinForms flags | 5 | 5 |
| **settings read** | **43** | *moved after the icon* |
| mutex + version file | 3 | 9 |
| **images** | **8** | **3** |
| `NotifyIcon` | 9 | 10 |
| **icon visible** | **121 ms** | **81 ms** |

Time to fully ready is unchanged at ~210 ms, which is the honest summary: this moves the wait rather than removing much of it, and the wait it moves is the one the user is watching.

## The icon before the settings file

Nothing between the two needs a setting — `AlwaysKill` and the hot keys are both used further down — and until that line there is nothing in the notification area to look at. Still after the mutex, so a second instance exits without ever showing an icon. Worth 33 ms.

## Images decoded on first use

A static constructor decoded all eleven the moment anything touched one, and the first thing to touch one is the tray icon, where only `Default` is wanted. Four more are on the fixed menu items; the last five are only ever shown when something is pending.

`Lazy<T>` rather than field initialisers, which would not have helped — the runtime initialises a type's static fields together, so `Default` would still have brought the other ten with it. Thread safe because the icon is set from the scan timer as well as from the UI thread. Worth 5 ms, and it stops decoding images for a menu that may never have anything in it.

## Settings through a source generated context

And read whole and parsed in one go rather than off an async `FileStream`. Together 31 ms → 21 ms — less than the generator promises, and worth saying plainly:

- source generation: **4 ms**
- dropping the async machinery: **6 ms**
- what remains: **~20 ms** of System.Text.Json being loaded and jitted for the first time, which no amount of generated code avoids for a file under 200 bytes

Kept anyway, since it is strictly cheaper and keeps the reflection based serialiser off the startup path — the part that grows on a cold start.

## Deliberately not touched

**`Logging.Init`, 23 ms, still ahead of the icon.** It could move after it, but then `"Mutex already exists. Exiting."` and anything the `Main` catch reports would have nowhere to go. A tray that failed to start with no explanation costs more than 23 ms is worth.

**43 ms in `new ContextMenuStrip`, plus 15 ms building its items.** Already after the icon is up. Deferring them to the first right click only moves the cost to somewhere the user is waiting on it.

The duplicate `EnableVisualStyles` / `SetCompatibleTextRenderingDefault` calls go with the reorder: `Main` already makes both immediately before calling `Inner`.

## Tests

Full solution: 1905 tests, 0 failed, 20 skipped. `ImagesTest` already touches every image, so the lazy fields stay covered, and `SettingsHelperTests.ReadWrite` pins that the written JSON is unchanged.
