### PR TITLE
Detect Bitbucket Pipelines as a build server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,7 @@ Supports:
  * [MyGet](https://docs.myget.org/docs/reference/build-services#Available_Environment_Variables)
  * [GitLab](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)
  * [GoCD](https://docs.gocd.org/current/faq/dev_use_current_revision_in_build.html)
+ * [Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#Default-variables)
 
 There are also individual properties to check for each specific build system
 
@@ -161,8 +162,9 @@ var isMyGet = BuildServerDetector.IsMyGet;
 var isGoDc = BuildServerDetector.IsGoDc;
 var isDocker = BuildServerDetector.IsDocker;
 var isAppVeyor = BuildServerDetector.IsAppVeyor;
+var isBitbucketPipelines = BuildServerDetector.IsBitbucketPipelines;
 ```
-<sup><a href='/src/DiffEngine.Tests/BuildServerDetectorTest.cs#L8-L22' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildServerDetectorProps' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/DiffEngine.Tests/BuildServerDetectorTest.cs#L8-L23' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildServerDetectorProps' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -206,7 +208,7 @@ public async Task SetDetectedDoesNotLeakToOtherContexts()
     await Assert.That(BuildServerDetector.Detected).IsEqualTo(parentValue);
 }
 ```
-<sup><a href='/src/DiffEngine.Tests/BuildServerDetectorTest.cs#L27-L62' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildServerDetectorDetectedOverride' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/DiffEngine.Tests/BuildServerDetectorTest.cs#L28-L63' title='Snippet source file'>snippet source</a> | <a href='#snippet-BuildServerDetectorDetectedOverride' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/readme.source.md
+++ b/readme.source.md
@@ -71,6 +71,7 @@ Supports:
  * [MyGet](https://docs.myget.org/docs/reference/build-services#Available_Environment_Variables)
  * [GitLab](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)
  * [GoCD](https://docs.gocd.org/current/faq/dev_use_current_revision_in_build.html)
+ * [Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#Default-variables)
 
 There are also individual properties to check for each specific build system
 

--- a/src/DiffEngine.Tests/BuildServerDetectorTest.cs
+++ b/src/DiffEngine.Tests/BuildServerDetectorTest.cs
@@ -18,6 +18,7 @@ public class BuildServerDetectorTest
         var isGoDc = BuildServerDetector.IsGoDc;
         var isDocker = BuildServerDetector.IsDocker;
         var isAppVeyor = BuildServerDetector.IsAppVeyor;
+        var isBitbucketPipelines = BuildServerDetector.IsBitbucketPipelines;
 
         #endregion
 

--- a/src/DiffEngine/BuildServerDetector.cs
+++ b/src/DiffEngine/BuildServerDetector.cs
@@ -43,6 +43,10 @@ public static class BuildServerDetector
         // https://www.appveyor.com/docs/environment-variables/
         IsAppVeyor = variables.Contains("APPVEYOR");
 
+        // Bitbucket Pipelines
+        // https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#Default-variables
+        IsBitbucketPipelines = variables.Contains("BITBUCKET_BUILD_NUMBER");
+
         IsWsl = variables.Contains("WSL_DISTRO_NAME");
 
         // AzureDevops
@@ -62,7 +66,8 @@ public static class BuildServerDetector
                    IsGoDc ||
                    IsDocker ||
                    IsWsl ||
-                   IsAppVeyor;
+                   IsAppVeyor ||
+                   IsBitbucketPipelines;
     }
 
     static bool detected;
@@ -82,6 +87,8 @@ public static class BuildServerDetector
     public static bool IsWsl { get; }
 
     public static bool IsAppVeyor { get; }
+
+    public static bool IsBitbucketPipelines { get; }
 
     public static bool IsTravis { get; }
 


### PR DESCRIPTION
`BuildServerDetector` did not know about [Bitbucket Pipelines](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#Default-variables), so a test run there had `Detected` false and diff tools were launched (or attempted) on the agent.

`BITBUCKET_BUILD_NUMBER` is one of the default variables Bitbucket Cloud sets for every pipeline build, whatever triggered it, so its presence is the marker — the same shape the other providers use. It is also what Cake and NUKE key their Bitbucket detection on.

- `IsBitbucketPipelines` added beside the other properties, and to the `detected` chain.
- Added to the `BuildServerDetectorProps` snippet and the readme's supported list (readme.md regenerated with MarkdownSnippets).

`DiffEngine.Tests` passes locally on Windows, net10.0: 661 passed, 7 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmaZicjXLGgc4bQYsHDiL6